### PR TITLE
docs: build public project portfolio

### DIFF
--- a/.github/workflows/publication-safety.yml
+++ b/.github/workflows/publication-safety.yml
@@ -1,0 +1,19 @@
+name: Publication safety
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  safety:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Run publication safety gate
+        run: python3 scripts/check_publication_safety.py

--- a/README.md
+++ b/README.md
@@ -1,13 +1,71 @@
 # DGX Cluster Public
 
-This repository is a public project interface and publication surface for reusable lessons from local multi-system AI infrastructure work. It will present privacy-reviewed material about validation, reliability, and clear technical documentation without exposing a live environment.
+I built this repository to explain the engineering discipline behind a local multi-system AI lab without publishing the lab itself. The useful work is the method: define identity before action, measure before changing, preserve rollback, and leave an evidence trail another operator can review.
 
-## High-level scope
+## What I built
 
-Future material may cover general infrastructure design patterns, repeatable validation methods, reliability principles, and documentation practices.
+This public surface organizes reusable patterns for:
 
-## Non-operational boundary
+- infrastructure intent and system boundaries;
+- repeatable readiness and validation checks;
+- observability that separates reachability, authorization, transport, and workload health;
+- controlled experiments with explicit stop conditions;
+- recovery notes that preserve what failed, what changed, and what remains unknown; and
+- publication checks that keep private operations out of public documentation.
 
-This is not an operational deployment repository. It excludes addresses, hostnames, hardware identifiers, account names, local paths, credentials, raw telemetry, live topology, outlet or device maps, controller identities, service or port inventories, and operational commands.
+## Why it matters
 
-Future technical material will be added only after privacy review. No test result or operational status is claimed by this initial repository.
+A cluster can appear healthy while one layer is quietly wrong. A reachable host is not proof of a usable workload path. A fast benchmark is not proof of repeatability. A successful repair is not complete until the rollback and evidence are documented.
+
+I treat those distinctions as part of the system, not as paperwork after the fact.
+
+## Engineering approach
+
+1. Start with declared intent and stable logical roles.
+2. Resolve each target through a private source of truth.
+3. Observe the smallest surface that can answer the question.
+4. Separate discovery, validation, mutation, and acceptance.
+5. Make risky steps reversible and bounded.
+6. Record failures and corrections instead of flattening them into a success story.
+7. Publish only synthetic examples after a privacy gate.
+
+## Synthetic public-safe architecture
+
+The architecture diagram uses documentation-only names and addresses. It demonstrates the validation flow without reproducing a live topology.
+
+See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
+
+## Representative work and artifacts
+
+- [Case study](docs/CASE-STUDY.md) - how I turn an ambiguous infrastructure symptom into a bounded validation program.
+- [Synthetic observation](examples/synthetic-cluster-observation.json) - a JSON-first example with documentation-only identities.
+- [Publication safety](docs/PUBLICATION-SAFETY.md) - the boundary enforced before material reaches this repository.
+- [Share copy](docs/SHARE.md) - concise language for explaining the work without overstating it.
+- [Safety checker](scripts/check_publication_safety.py) - a standard-library repository scan used locally and in CI.
+
+## Evidence and lessons
+
+The evidence in this repository is limited to the public artifacts themselves: valid JSON, reviewable diagrams, documented gates, and an automated privacy scan. No synthetic example is presented as a live test result.
+
+The main lesson is simple: repeatability comes from preserving identity, assumptions, actions, expected outcomes, actual outcomes, and rollback conditions as separate fields.
+
+## Repository map
+
+| Path | Purpose |
+|---|---|
+| README.md | Project narrative and limits |
+| docs/CASE-STUDY.md | Original portfolio case study |
+| docs/ARCHITECTURE.md | Synthetic Mermaid architecture |
+| docs/PUBLICATION-SAFETY.md | Publication rules |
+| docs/SHARE.md | Short and thread-style share copy |
+| examples/ | Synthetic JSON evidence shapes |
+| scripts/check_publication_safety.py | Local privacy and structure gate |
+| .github/workflows/publication-safety.yml | Continuous publication check |
+
+## Publication boundary
+
+This is a public project interface, not an operational deployment repository. I do not publish live addresses, hostnames, hardware identities, account details, local paths, credentials, raw telemetry, service inventories, private topology, or equipment maps. Examples are synthetic and do not reproduce a live environment.
+
+## Limitations
+
+This repository does not prove a specific cluster size, topology, benchmark result, operational status, or production outcome. It deliberately omits the details needed to target or reproduce a private environment. Future evidence will be added only when it is both technically defensible and safe to publish.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,11 @@
+```mermaid
+flowchart LR
+  O["Operator intent"] --> C["control-a.example<br/>192.0.2.20"]
+  C --> I["Identity and readiness gates"]
+  I --> N["compute-a.example<br/>192.0.2.10"]
+  N --> V["Transport and workload validation"]
+  V --> E["evidence.example<br/>192.0.2.30"]
+  E --> A{"Acceptance met?"}
+  A -->|No| R["Rollback or focused diagnosis"]
+  A -->|Yes| D["Sanitized result record"]
+```

--- a/docs/CASE-STUDY.md
+++ b/docs/CASE-STUDY.md
@@ -1,0 +1,64 @@
+# Case Study: Turning Cluster Ambiguity Into Reviewable Evidence
+
+## Context
+
+Local AI infrastructure crosses several layers at once: physical links, addressing, host identity, transport, collective communication, storage, services, and workloads. When one layer fails, the visible symptom can point in the wrong direction.
+
+I wanted a method that reduced guesswork without turning every incident into a broad reconfiguration.
+
+## Problem
+
+The common failure pattern is premature action:
+
+- a host responds, so the workload path is assumed healthy;
+- one benchmark passes, so repeatability is assumed;
+- a configuration looks correct, so the physical path is assumed; and
+- a recovery works once, so it is treated as automation-ready.
+
+Those shortcuts hide mismatches and make rollback harder.
+
+## What I built
+
+I organized the work around a compact evidence loop:
+
+1. State the intended role and acceptance condition.
+2. Resolve a synthetic target such as compute-a.example.
+3. Collect read-only evidence from the smallest relevant layer.
+4. Classify the result as observed, measured, failed, planned, or unknown.
+5. Propose one bounded change with a rollback condition.
+6. Re-run the same acceptance check.
+7. Store a structured receipt.
+
+The companion JSON example shows how the receipt can stay machine-readable without containing a real inventory.
+
+## Engineering decisions
+
+- Identity is explicit and never inferred from a label alone.
+- Network reachability, authorization, transport readiness, and workload health are separate gates.
+- Experiments have stop conditions before they have actions.
+- A failed check remains failed until the targeted rerun passes.
+- Synthetic public records preserve the method while private evidence remains private.
+
+## Representative artifact
+
+The synthetic cluster observation example uses a documentation-only host and address. It records intent, evidence class, gates, and an acceptance decision. The values are illustrative and were not collected from a live system.
+
+## Evidence available here
+
+The public evidence is structural:
+
+- the example parses as JSON;
+- the architecture is explicitly synthetic;
+- the repository checker rejects common private-data patterns;
+- CI runs the same checker on every change; and
+- the documentation states what is not proven.
+
+## Lessons
+
+The most valuable cluster tool is not a single command. It is a disciplined boundary between what I know, what I infer, what I am allowed to change, and what must be verified afterward.
+
+That boundary makes experiments easier to repeat and failures easier to explain.
+
+## Limitations
+
+This case study does not disclose or recreate a live topology. It contains no operational inventory, benchmark, host count, equipment map, or current status. It is a public description of the engineering method only.

--- a/docs/PUBLICATION-SAFETY.md
+++ b/docs/PUBLICATION-SAFETY.md
@@ -1,0 +1,30 @@
+# Publication Safety
+
+## Purpose
+
+I use this repository to publish the cluster engineering method, not the cluster. Every example must remain synthetic and non-operational.
+
+## Allowed
+
+- Fictional names under the example namespaces.
+- Documentation-only address ranges.
+- General validation and reliability patterns.
+- Synthetic JSON with clearly labeled illustrative outcomes.
+- Limitations and failed assumptions that do not identify a live environment.
+
+## Excluded
+
+- Live network or hardware identity.
+- Accounts, credentials, keys, tokens, and local paths.
+- Raw logs, telemetry, inventories, service listings, and equipment maps.
+- Exact system counts, operational measurements, and current status.
+- Screenshots, photos, or copied private artifacts.
+- Commands aimed at real systems.
+
+## Project-specific review
+
+Cluster material must not reveal how private roles connect, how many systems exist, or which services share a dependency. Architecture examples describe a validation pattern only.
+
+## Gate
+
+The standard-library checker validates required files, JSON syntax, Mermaid-only architecture, and common private-data patterns. CI runs the same gate. A passing scan reduces publication risk but does not replace human review.

--- a/docs/SHARE.md
+++ b/docs/SHARE.md
@@ -1,0 +1,27 @@
+# Share Copy
+
+## Short post
+
+I turned my local AI cluster work into a public-safe engineering record. The useful part is not my topology. It is the discipline: identity before action, evidence before change, rollback before risk, and clear limits on every claim.
+
+## Thread-style post
+
+**Opening**
+
+I have been documenting the engineering method behind my local AI infrastructure without publishing the environment itself.
+
+**What I built**
+
+A compact public framework for readiness checks, layered observability, bounded experiments, rollback, and evidence receipts.
+
+**What changed in my thinking**
+
+Reachability is not workload health. One fast run is not repeatability. A repair is not complete until the acceptance check and rollback are documented.
+
+**How I kept it safe**
+
+Every host and address is synthetic. The repository has an automated privacy gate and contains no live inventory, telemetry, equipment map, or operational target.
+
+**Bottom line**
+
+The portfolio is about making infrastructure work explainable and repeatable, including the failures and unknowns.

--- a/examples/synthetic-cluster-observation.json
+++ b/examples/synthetic-cluster-observation.json
@@ -1,0 +1,46 @@
+{
+  "schema_version": "public-example-v1",
+  "synthetic": true,
+  "purpose": "Demonstrate a layered cluster observation receipt without reproducing a live environment.",
+  "subject": {
+    "role": "representative_compute",
+    "hostname": "compute-a.example",
+    "address": "192.0.2.10"
+  },
+  "intent": {
+    "operation": "read_only_validation",
+    "acceptance": "All declared gates have current evidence and no unresolved identity mismatch."
+  },
+  "gates": [
+    {
+      "name": "identity",
+      "result": "pass",
+      "evidence_class": "synthetic"
+    },
+    {
+      "name": "management_reachability",
+      "result": "pass",
+      "evidence_class": "synthetic"
+    },
+    {
+      "name": "transport_readiness",
+      "result": "unknown",
+      "evidence_class": "not_collected"
+    },
+    {
+      "name": "workload_health",
+      "result": "unknown",
+      "evidence_class": "not_collected"
+    }
+  ],
+  "decision": {
+    "status": "not_accepted",
+    "reason": "Dependent evidence remains unknown.",
+    "next_step": "Collect the missing read-only evidence or stop."
+  },
+  "limitations": [
+    "Illustrative data only.",
+    "No live command was run.",
+    "No operational result is claimed."
+  ]
+}

--- a/scripts/check_publication_safety.py
+++ b/scripts/check_publication_safety.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Fail closed when public repository text contains likely private data."""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SELF = Path("scripts/check_publication_safety.py")
+FENCE = chr(96) * 3
+REQUIRED_FILES = {
+    Path("README.md"),
+    Path("docs/CASE-STUDY.md"),
+    Path("docs/ARCHITECTURE.md"),
+    Path("docs/PUBLICATION-SAFETY.md"),
+    Path("docs/SHARE.md"),
+    Path(".github/workflows/publication-safety.yml"),
+    SELF,
+}
+TEXT_SUFFIXES = {".md", ".json", ".py", ".yml", ".yaml", ".txt", ".toml"}
+FORBIDDEN_NETWORKS = tuple(
+    ipaddress.ip_network(value)
+    for value in ("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "100.64.0.0/10")
+)
+ALLOWED_DOCUMENTATION_NETWORKS = tuple(
+    ipaddress.ip_network(value)
+    for value in ("192.0.2.0/24", "198.51.100.0/24", "203.0.113.0/24")
+)
+IPV4 = re.compile(r"(?<![0-9])(?:[0-9]{1,3}\.){3}[0-9]{1,3}(?![0-9])")
+PATTERNS = {
+    "private_key_block": re.compile(r"BEGIN [A-Z ]*PRIVATE KEY"),
+    "github_token": re.compile(r"\b(?:gh[pousr]_[A-Za-z0-9_]+|github_pat_[A-Za-z0-9_]+)\b"),
+    "cloud_key": re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+    "slack_token": re.compile(r"\bxox[baprs]-[A-Za-z0-9-]+\b"),
+    "email": re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b"),
+    "mac_address": re.compile(r"\b(?:[0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}\b"),
+    "uuid": re.compile(r"\b[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}\b"),
+    "serial_like": re.compile(r"\b(?=[A-Z0-9]*[A-Z])(?=[A-Z0-9]*[0-9])[A-Z0-9]{10,}\b"),
+    "multicast_local_hostname": re.compile(r"\b[A-Za-z0-9-]+[.]local\b", re.IGNORECASE),
+    "mac_home_path": re.compile(r"/Users/[A-Za-z0-9._-]+"),
+    "posix_home_path": re.compile(r"/home/[A-Za-z0-9._-]+"),
+    "windows_home_path": re.compile(r"[A-Za-z]:\\Users\\[^\\\s]+"),
+    "secret_assignment": re.compile(
+        r"""(?i)\b(?:api[_-]?key|password|secret|access[_-]?token)\b\s*[:=]\s*["'][^"']+["']"""
+    ),
+    "sensitive_mapping_field": re.compile(
+        r"""(?i)["']?(?:device_id|hardware_id|serial_number|mac_address|outlet_map|controller_map|live_topology|service_inventory)["']?\s*[:=]"""
+    ),
+    "private_source_link": re.compile(r"https://github[.]com/GumbiiDigital/(?![A-Za-z0-9._-]+-public(?:\b|/))"),
+    "markdown_image": re.compile(r"!\[[^]]*\]\([^)]+\)"),
+}
+LINK = re.compile(r"(?<!!)\[[^]]+\]\(([^)]+)\)")
+
+
+def repository_files() -> list[Path]:
+    files: list[Path] = []
+    for path in ROOT.rglob("*"):
+        relative = path.relative_to(ROOT)
+        if ".git" in relative.parts or "__pycache__" in relative.parts:
+            continue
+        if path.is_symlink():
+            raise ValueError(f"symlink is not allowed: {relative}")
+        if path.is_file():
+            files.append(relative)
+    return sorted(files)
+
+
+def scan_text(relative: Path, text: str, failures: list[str]) -> None:
+    for name, pattern in PATTERNS.items():
+        for match in pattern.finditer(text):
+            line = text.count("\n", 0, match.start()) + 1
+            failures.append(f"{relative}:{line}: prohibited pattern {name}")
+
+    for match in IPV4.finditer(text):
+        value = match.group(0)
+        try:
+            address = ipaddress.ip_address(value)
+        except ValueError:
+            failures.append(f"{relative}: invalid IPv4-like value {value}")
+            continue
+        if any(address in network for network in FORBIDDEN_NETWORKS):
+            failures.append(f"{relative}: private or CGNAT address {value}")
+        elif not any(address in network for network in ALLOWED_DOCUMENTATION_NETWORKS):
+            failures.append(f"{relative}: non-documentation address {value}")
+
+    if relative.suffix == ".md":
+        if text.count(FENCE) % 2:
+            failures.append(f"{relative}: unbalanced Markdown code fence")
+        first = next((line for line in text.splitlines() if line.strip()), "")
+        if relative == Path("docs/ARCHITECTURE.md"):
+            lines = [line for line in text.splitlines() if line.strip()]
+            fence_lines = [line for line in lines if line.startswith(FENCE)]
+            if not lines or lines[0] != f"{FENCE}mermaid" or lines[-1] != FENCE or len(fence_lines) != 2:
+                failures.append(f"{relative}: architecture must contain one Mermaid fence and no prose")
+        elif not first.startswith("#"):
+            failures.append(f"{relative}: first non-empty line must be a heading")
+
+        for target in LINK.findall(text):
+            if target.startswith("#") or "://" in target:
+                continue
+            clean = target.split("#", 1)[0]
+            resolved = (ROOT / relative.parent / clean).resolve()
+            if clean and not resolved.is_relative_to(ROOT.resolve()):
+                failures.append(f"{relative}: link escapes repository: {target}")
+            elif clean and not resolved.exists():
+                failures.append(f"{relative}: broken relative link: {target}")
+
+
+def main() -> int:
+    failures: list[str] = []
+    try:
+        files = repository_files()
+    except ValueError as exc:
+        print(f"publication safety: FAIL\n{exc}")
+        return 1
+
+    present = set(files)
+    missing = sorted(REQUIRED_FILES - present)
+    failures.extend(f"missing required file: {path}" for path in missing)
+
+    license_files = [path for path in files if path.name.upper().startswith("LICENSE")]
+    failures.extend(f"license file is not authorized: {path}" for path in license_files)
+
+    image_suffixes = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg"}
+    failures.extend(f"image asset is not authorized: {path}" for path in files if path.suffix.lower() in image_suffixes)
+
+    json_files = [path for path in files if path.suffix == ".json"]
+    if not json_files:
+        failures.append("at least one JSON example is required")
+
+    scanned = 0
+    for relative in files:
+        if relative == SELF or relative.suffix not in TEXT_SUFFIXES:
+            continue
+        path = ROOT / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+            text.encode("ascii")
+        except (UnicodeDecodeError, UnicodeEncodeError):
+            failures.append(f"{relative}: file must be ASCII text")
+            continue
+        scanned += 1
+        scan_text(relative, text, failures)
+        if relative.suffix == ".json":
+            try:
+                payload = json.loads(text)
+            except json.JSONDecodeError as exc:
+                failures.append(f"{relative}: invalid JSON: {exc}")
+                continue
+            if not isinstance(payload, dict) or payload.get("synthetic") is not True:
+                failures.append(f"{relative}: JSON example must declare synthetic true")
+
+    if failures:
+        print("publication safety: FAIL")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+
+    print(f"publication safety: PASS ({scanned} text files, {len(json_files)} JSON examples)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What changed

- replaces the thin project introduction with a substantial, tailored portfolio README
- adds an original case study, synthetic Mermaid architecture, publication-safety policy, and share-ready copy
- adds one tailored synthetic JSON example
- adds a Python standard-library publication checker and GitHub Actions safety workflow

## Evidence and privacy boundary

All content was authored fresh for this public repository. No private file, image, asset, history, topology, inventory, telemetry, credential, identifier, path, or operational measurement was imported.

Examples use fictional names and documentation-only addresses. They explicitly do not claim live execution or deployment status.

## Validation

- local publication checker: passed
- JSON syntax and synthetic marker: passed
- Mermaid-only architecture and Markdown link checks: passed
- staged file scope and diff whitespace: passed
- cross-repository prohibited-value and sensitive-field scans: passed
- commit identity uses the GitHub no-reply address

## Runtime impact

None. This is a public documentation and validation buildout only. It contains no operational deployment commands and changes no private repository or live system.
