### PR TITLE
docs: restore the real DGX Cluster engineering record

### DIFF
--- a/.github/workflows/publication-safety.yml
+++ b/.github/workflows/publication-safety.yml
@@ -15,5 +15,9 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+      - name: Compile Python
+        run: python3 -m compileall -q scripts
+      - name: Test NCCL log parser
+        run: python3 scripts/summarize_nccl_log.py --self-test
       - name: Run publication safety gate
         run: python3 scripts/check_publication_safety.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,71 +1,90 @@
-# DGX Cluster Public
+# DGX Cluster Engineering Record
 
-I built this repository to explain the engineering discipline behind a local multi-system AI lab without publishing the lab itself. The useful work is the method: define identity before action, measure before changing, preserve rollback, and leave an evidence trail another operator can review.
+This repository is the privacy-reviewed public record of how I brought up, repaired, tuned, and revalidated a local eight-system DGX Spark cluster. The measurements and engineering conclusions are real. Hostnames, addresses, physical port labels, and control mappings are sanitized public aliases so the work remains reviewable without exposing the live environment.
 
-## What I built
+## What is here
 
-This public surface organizes reusable patterns for:
+The record follows the work in the order it happened:
 
-- infrastructure intent and system boundaries;
-- repeatable readiness and validation checks;
-- observability that separates reachability, authorization, transport, and workload health;
-- controlled experiments with explicit stop conditions;
-- recovery notes that preserve what failed, what changed, and what remains unknown; and
-- publication checks that keep private operations out of public documentation.
+1. Establish management identity before connecting the high-speed fabric.
+2. Normalize the first systems to a repeatable software and firmware baseline.
+3. Refuse to treat link-up as proof of useful RoCE throughput.
+4. Isolate a switch forwarding failure that survived normal link, MTU, FEC, and vendor diagnostics.
+5. Repair the ASIC forwarding path and prove both logical rails with directed RDMA and NCCL.
+6. Tune separate four-system and eight-system NCCL profiles from repeated measurements.
+7. Revalidate the entire fabric after a physical rack recable.
+8. Commission rack-local BLE power control fail-closed after physical evidence disproved an early decoder assumption.
+9. Document the open-rack thermal design without claiming a fan test that was not completed.
 
-## Why it matters
+## Recorded results
 
-A cluster can appear healthy while one layer is quietly wrong. A reachable host is not proof of a usable workload path. A fast benchmark is not proof of repeatability. A successful repair is not complete until the rollback and evidence are documented.
+These are historical observations from the engineering record, not current service guarantees.
 
-I treat those distinctions as part of the system, not as paperwork after the fact.
+| Milestone | Recorded result |
+| --- | --- |
+| Initial four-system TCP baseline | roughly `9.3-9.43 Gbit/s`, with retransmits |
+| Initial raw RDMA | roughly `0.1-7 Gbit/s` |
+| Direct-cable diagnostic | `12.8 Gbit/s` TCP and `12.71 Gbit/s` RDMA |
+| Switch forwarding repair | `111.07 Gbit/s` on the repaired path |
+| Dual TCP pairs after repair | `197.62`, `198.00`, and `196.61 Gbit/s`, with zero retransmits |
+| Sequential RDMA after repair | `97.98 Gbit/s` on each logical rail |
+| Full post-rewire directed RDMA | `112/112` ordered pairs, mean `109.20 Gbit/s` |
+| Tuned eight-system NCCL at 256 MiB | mean `22.9965 GB/s`, wrong `0` |
+| Later rack revalidation | jumbo `112/112`; RDMA `112/112` after bounded serial retry; NCCL `23.8196 GB/s`, wrong `0` |
 
-## Engineering approach
-
-1. Start with declared intent and stable logical roles.
-2. Resolve each target through a private source of truth.
-3. Observe the smallest surface that can answer the question.
-4. Separate discovery, validation, mutation, and acceptance.
-5. Make risky steps reversible and bounded.
-6. Record failures and corrections instead of flattening them into a success story.
-7. Publish only synthetic examples after a privacy gate.
-
-## Synthetic public-safe architecture
-
-The architecture diagram uses documentation-only names and addresses. It demonstrates the validation flow without reproducing a live topology.
-
-See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
-
-## Representative work and artifacts
-
-- [Case study](docs/CASE-STUDY.md) - how I turn an ambiguous infrastructure symptom into a bounded validation program.
-- [Synthetic observation](examples/synthetic-cluster-observation.json) - a JSON-first example with documentation-only identities.
-- [Publication safety](docs/PUBLICATION-SAFETY.md) - the boundary enforced before material reaches this repository.
-- [Share copy](docs/SHARE.md) - concise language for explaining the work without overstating it.
-- [Safety checker](scripts/check_publication_safety.py) - a standard-library repository scan used locally and in CI.
-
-## Evidence and lessons
-
-The evidence in this repository is limited to the public artifacts themselves: valid JSON, reviewable diagrams, documented gates, and an automated privacy scan. No synthetic example is presented as a live test result.
-
-The main lesson is simple: repeatability comes from preserving identity, assumptions, actions, expected outcomes, actual outcomes, and rollback conditions as separate fields.
+The detailed context, failed hypotheses, and acceptance boundaries are preserved in the linked records. I do not flatten a long diagnosis into a benchmark screenshot.
 
 ## Repository map
 
-| Path | Purpose |
-|---|---|
-| README.md | Project narrative and limits |
-| docs/CASE-STUDY.md | Original portfolio case study |
-| docs/ARCHITECTURE.md | Synthetic Mermaid architecture |
-| docs/PUBLICATION-SAFETY.md | Publication rules |
-| docs/SHARE.md | Short and thread-style share copy |
-| examples/ | Synthetic JSON evidence shapes |
-| scripts/check_publication_safety.py | Local privacy and structure gate |
-| .github/workflows/publication-safety.yml | Continuous publication check |
+| Path | Contents |
+| --- | --- |
+| [docs/CASE-STUDY.md](docs/CASE-STUDY.md) | Chronological engineering narrative |
+| [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | Sanitized architecture and validation flow |
+| [docs/COMMISSIONING.md](docs/COMMISSIONING.md) | Identity-first bring-up and parity gates |
+| [docs/FABRIC-TROUBLESHOOTING.md](docs/FABRIC-TROUBLESHOOTING.md) | RoCE diagnosis, forwarding root cause, repair, and rollback discipline |
+| [docs/NCCL-TUNING-RECORD.md](docs/NCCL-TUNING-RECORD.md) | Four-system and eight-system profiles with measured results |
+| [docs/RACK-RECABLE-REVALIDATION.md](docs/RACK-RECABLE-REVALIDATION.md) | Post-rewire fault and complete acceptance rerun |
+| [docs/POWER-BLE-COMMISSIONING.md](docs/POWER-BLE-COMMISSIONING.md) | Raspberry Pi BLE work and the fail-closed correction |
+| [docs/RECOVERY-POLICY.md](docs/RECOVERY-POLICY.md) | Guarded recovery decision and refusal logic |
+| [docs/THERMAL-MANAGEMENT.md](docs/THERMAL-MANAGEMENT.md) | Open-rack airflow design and the uncompleted differential test |
+| [docs/SOURCE-ADAPTATION.md](docs/SOURCE-ADAPTATION.md) | What was preserved and what was sanitized |
+| [examples/sanitized-cluster-aliases.json](examples/sanitized-cluster-aliases.json) | Internally consistent public aliases |
+| [examples/nccl-profiles.json](examples/nccl-profiles.json) | Recorded tuning profiles and public-safe launcher aliases |
+| [examples/recovery-policy.json](examples/recovery-policy.json) | Machine-readable guarded policy example |
+| [scripts/summarize_nccl_log.py](scripts/summarize_nccl_log.py) | Local parser for `nccl-tests` output |
+| [scripts/check_publication_safety.py](scripts/check_publication_safety.py) | Fail-closed publication scan |
+
+## Architecture boundary
+
+The public diagram uses `spark-a.example` through `spark-h.example` and RFC 5737 documentation addresses. Those aliases preserve the management-plane and dual-rail relationships, but they do not reproduce live identity, addressing, switch-port numbering, power mapping, or remote-access endpoints.
+
+The interface and transport names are retained because they explain the engineering result:
+
+```text
+NCCL_IB_HCA=rocep1s0f1,roceP2p1s0f1
+NCCL_SOCKET_IFNAME=enp1s0f1np1,enP2p1s0f1np1
+UCX_NET_DEVICES=enp1s0f1np1,enP2p1s0f1np1
+```
+
+## How I treat evidence
+
+- A management ping is not a workload-health result.
+- A physical `200G` link is not proof of application throughput.
+- A protocol acknowledgement is not proof that the intended relay moved.
+- A one-off peak is not a frozen tuning profile.
+- A repair is not complete until the original gate is rerun and the rollback is recorded.
+- Unknown state stays unknown. It is not converted into green status for convenience.
 
 ## Publication boundary
 
-This is a public project interface, not an operational deployment repository. I do not publish live addresses, hostnames, hardware identities, account details, local paths, credentials, raw telemetry, service inventories, private topology, or equipment maps. Examples are synthetic and do not reproduce a live environment.
+The private working repository remains the operational source of truth. This public repository omits credentials, accounts, personal paths, raw captures, raw logs, hardware identifiers, controller identities, exact physical mappings, and current operational status. It preserves non-identifying measurements and engineering decisions because those are the substance of the work.
+
+See [docs/PUBLICATION-SAFETY.md](docs/PUBLICATION-SAFETY.md) for the enforced boundary.
 
 ## Limitations
 
-This repository does not prove a specific cluster size, topology, benchmark result, operational status, or production outcome. It deliberately omits the details needed to target or reproduce a private environment. Future evidence will be added only when it is both technically defensible and safe to publish.
+- The measurements describe the recorded test conditions, not every workload or software version.
+- The public aliases are not valid deployment inventory.
+- The BLE work proves an identity-verified read path and a critical decoder correction; it does not claim unattended relay recovery is enabled.
+- The thermal design is documented, but the planned fan-off/fan-on differential was deferred and no cooling delta is claimed.
+- No license has been selected for this repository.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,11 +1,22 @@
 ```mermaid
-flowchart LR
-  O["Operator intent"] --> C["control-a.example<br/>192.0.2.20"]
-  C --> I["Identity and readiness gates"]
-  I --> N["compute-a.example<br/>192.0.2.10"]
-  N --> V["Transport and workload validation"]
-  V --> E["evidence.example<br/>192.0.2.30"]
-  E --> A{"Acceptance met?"}
-  A -->|No| R["Rollback or focused diagnosis"]
-  A -->|Yes| D["Sanitized result record"]
+flowchart TB
+  O["Operator and evidence harness"] --> M["Management network<br/>192.0.2.0/24"]
+  M --> A["spark-a.example"]
+  M --> B["spark-b.example"]
+  M --> C["spark-c.example"]
+  M --> D["spark-d.example"]
+  M --> E["spark-e.example"]
+  M --> F["spark-f.example"]
+  M --> G["spark-g.example"]
+  M --> H["spark-h.example"]
+  A & B & C & D & E & F & G & H --> R0["RoCE rail 0<br/>198.51.100.0/24"]
+  A & B & C & D & E & F & G & H --> R1["RoCE rail 1<br/>203.0.113.0/24"]
+  R0 --> S["fabric-switch.example<br/>CRS804-4DDQ"]
+  R1 --> S
+  S --> V["Jumbo ping and directed RDMA gates"]
+  V --> N["NCCL transport, correctness, and repeatability gates"]
+  N --> EVIDENCE["Versioned result record"]
+  EVIDENCE --> DECISION{"Acceptance met?"}
+  DECISION -->|"No"| STOP["Stop, isolate one layer, preserve rollback"]
+  DECISION -->|"Yes"| FREEZE["Freeze profile and revalidate after change"]
 ```

--- a/docs/CASE-STUDY.md
+++ b/docs/CASE-STUDY.md
@@ -1,64 +1,149 @@
-# Case Study: Turning Cluster Ambiguity Into Reviewable Evidence
+# Case Study: From Link-Up to a Defensible Eight-System Fabric
 
-## Context
+## The problem I was actually solving
 
-Local AI infrastructure crosses several layers at once: physical links, addressing, host identity, transport, collective communication, storage, services, and workloads. When one layer fails, the visible symptom can point in the wrong direction.
+The hardware could report healthy links while the useful data path remained slow. That distinction shaped the entire build. I needed to know whether management identity, physical link, Ethernet forwarding, RDMA, MPI launch, and NCCL collectives all worked independently and together.
 
-I wanted a method that reduced guesswork without turning every incident into a broad reconfiguration.
+I did not want a cluster that looked complete because the LEDs were green. I wanted a sequence of gates that would fail at the layer that was actually broken.
 
-## Problem
+## Recorded timeline
 
-The common failure pattern is premature action:
+| Date | Engineering milestone |
+| --- | --- |
+| 2026-06-28 | First-system identity and management bring-up |
+| 2026-06-29 | Four-system parity and underlay baseline |
+| 2026-06-30 | RoCE isolation, topology correction, and switch forwarding repair |
+| 2026-07-01 | Four-system NCCL validation and profile work |
+| 2026-07-03 | Eight-system recable repair and NCCL tuning |
+| 2026-07-17 | Raspberry Pi BLE commissioning and fail-closed correction |
+| 2026-07-21 | Post-rack topology rerun and thermal-management documentation |
 
-- a host responds, so the workload path is assumed healthy;
-- one benchmark passes, so repeatability is assumed;
-- a configuration looks correct, so the physical path is assumed; and
-- a recovery works once, so it is treated as automation-ready.
+## Phase 1: identity before fabric
 
-Those shortcuts hide mismatches and make rollback harder.
+The first systems came online through ordinary management Ethernet. Each one had to pass hostname, address, SSH, GPU, software, service, and firmware checks before I treated the cable label as trustworthy or attached the high-speed fabric.
 
-## What I built
+That caught an early naming problem: a newly detected system and an existing synchronization target could have been mistaken for the same machine. The operating rule became explicit: detect first, prove host identity, then label the physical system.
 
-I organized the work around a compact evidence loop:
+The first four systems were normalized to:
 
-1. State the intended role and acceptance condition.
-2. Resolve a synthetic target such as compute-a.example.
-3. Collect read-only evidence from the smallest relevant layer.
-4. Classify the result as observed, measured, failed, planned, or unknown.
-5. Propose one bounded change with a rollback condition.
-6. Re-run the same acceptance check.
-7. Store a structured receipt.
+- Ubuntu `24.04.4`;
+- NVIDIA kernel `6.17.0-1021-nvidia`;
+- NVIDIA driver `580.159.03`;
+- CUDA `13.0` in the recorded baseline;
+- no failed services;
+- no reboot-required marker; and
+- current firmware status at the time of the check.
 
-The companion JSON example shows how the receipt can stay machine-readable without containing a real inventory.
+One system required the matching open NVIDIA kernel module. Another had a failed one-time service that was reset and rerun. Those corrections stayed in the record because parity is a measured state, not a visual assumption.
 
-## Engineering decisions
+## Phase 2: the first performance result was a stop sign
 
-- Identity is explicit and never inferred from a label alone.
-- Network reachability, authorization, transport readiness, and workload health are separate gates.
-- Experiments have stop conditions before they have actions.
-- A failed check remains failed until the targeted rerun passes.
-- Synthetic public records preserve the method while private evidence remains private.
+The initial fabric had `200000 Mb/s` links and MTU `9000`, but the application path did not match that physical state:
 
-## Representative artifact
+- TCP was roughly `9.3-9.43 Gbit/s`, with retransmits;
+- raw RDMA varied from roughly `0.1-7 Gbit/s`; and
+- a reboot did not repair either logical function.
 
-The synthetic cluster observation example uses a documentation-only host and address. It records intent, evidence class, gates, and an acceptance decision. The values are illustrative and were not collected from a live system.
+I stopped before treating NCCL as a fabric benchmark. A collective benchmark on a broken underlay would have produced a number, but not a useful conclusion.
 
-## Evidence available here
+## Phase 3: eliminate the easy explanations
 
-The public evidence is structural:
+The switch was upgraded to RouterOS `7.23.1` after backup and export. The recorded configuration work included:
 
-- the example parses as JSON;
-- the architecture is explicitly synthetic;
-- the repository checker rejects common private-data patterns;
-- CI runs the same checker on every change; and
-- the documentation states what is not proven.
+- `200G-baseCR4` links;
+- MTU `9000`;
+- source-backed RoCE QoS using DSCP `26` for traffic class 3;
+- CNP `48` for traffic class 6;
+- ECN on traffic class 3;
+- PFC on traffic class 3; and
+- a `100 Gbit/s` egress rate because that was the platform limit for the setting.
 
-## Lessons
+Queue 3 counters moved with zero drops, but raw RDMA remained roughly `5-7 Gbit/s`, and TCP remained roughly `8-9 Gbit/s` with retransmits. Cold-drain tests and a bounded PFC bypass did not fix it.
 
-The most valuable cluster tool is not a single command. It is a disciplined boundary between what I know, what I infer, what I am allowed to change, and what must be verified afterward.
+MFT `4.35.0.159-1` reported both active functions at `200G x4`, Standard RS-FEC, and no observed issue. A direct system-to-system cable then produced `12.8 Gbit/s` TCP without retransmits and `12.71 Gbit/s` RDMA. That proved the switch made the symptom worse, but it also showed the host path was not yet near the intended per-rail gate.
 
-That boundary makes experiments easier to repeat and failures easier to explain.
+## Phase 4: align the physical and logical shape
 
-## Limitations
+The source-backed known-good layout used the second ConnectX-7 port on every system, exposing two logical functions on separate subnets. The public aliases retain that relationship:
 
-This case study does not disclose or recreate a live topology. It contains no operational inventory, benchmark, host count, equipment map, or current status. It is a public description of the engineering method only.
+- rail 0: `enp1s0f1np1` / `rocep1s0f1`;
+- rail 1: `enP2p1s0f1np1` / `roceP2p1s0f1`; and
+- one subnet per rail.
+
+Putting both logical functions on one subnet was rejected because it created route ambiguity and invalid NCCL behavior. The physical move was followed by read-only link checks before any performance claim.
+
+## Phase 5: find the switch forwarding failure
+
+The decisive symptom was switch CPU traffic. High-rate fabric frames were reaching the switch CPU path and being dropped even though the bridge host table and ARP state looked correct.
+
+Before the repair:
+
+- TCP was roughly `9 Gbit/s` per half, with retransmits;
+- UDP receive was roughly `9.9 Gbit/s` with about `87%` loss; and
+- the switch CPU queue added roughly `16.9 million` dropped packets and about `152 GB` of dropped traffic.
+
+Explicit destination forwarding rules moved the learned fabric destinations back to the Marvell Prestera ASIC path. The rules used live-learned relationships, were backed up first, and had a comment-based rollback.
+
+After the repair:
+
+- one repaired path reached `111.07 Gbit/s` with one retransmit;
+- dual TCP pair results were `197.62`, `198.00`, and `196.61 Gbit/s`, all with zero retransmits; and
+- sequential RDMA on both logical rails reached `97.98 Gbit/s`.
+
+The root cause was not FEC, MTU, cable link-up, or host RDMA device absence. It was a forwarding-path error that ordinary link health did not expose.
+
+## Phase 6: recable, break the mapping, and prove the repair
+
+A later rack recable left stale static forwarding destinations on four systems. The links were still physically healthy, but the old logical-to-physical relationship stranded those nodes.
+
+Before the correction, the small-packet matrix passed only `24/112` directed paths. I captured switch backup/export state, changed only the stale forwarding destinations, and reran the same acceptance program.
+
+After the correction:
+
+- small ping passed `112/112`;
+- jumbo ping passed `112/112`;
+- directed RDMA passed `112/112`;
+- RDMA ranged from `109.06-109.30 Gbit/s`, mean `109.20 Gbit/s`;
+- MPI fanout passed `8/8`;
+- the all-eight NCCL canary passed over `NET/IB`; and
+- the fixed `256 MiB` collective completed with wrong `0` and average bus bandwidth `20.1189 GB/s`.
+
+That final NCCL number was recorded as the repair baseline, not a peak.
+
+## Phase 7: tune only after the fabric was valid
+
+The frozen all-eight profile used two QPs per connection, no split across QPs, and twelve channels. Three longer `256 MiB` repeats produced `22.9494`, `23.0400`, and `23.0002 GB/s`, for a mean of `22.9965 GB/s` and wrong `0`.
+
+That was about `5.7%` above the pre-tuning all-eight baseline of `21.7487 GB/s`. A single quick run reached higher, but I did not freeze the one-off peak because the longer head-to-head set favored the twelve-channel profile for stability.
+
+The full result is in [NCCL-TUNING-RECORD.md](NCCL-TUNING-RECORD.md).
+
+## Phase 8: revalidate after the rack changed again
+
+After another teardown and reassembly, the full validation ran again rather than relying on the old success:
+
+- all eight management SSH checks passed;
+- all sixteen fabric interfaces were up at `200000 Mb/s`, MTU `9000`;
+- jumbo ping passed `112/112`;
+- `105/112` directed RDMA paths passed under the concurrent sweep;
+- the seven outliers passed a bounded serial retry at `111.85 Gbit/s`;
+- the secondary-rail mean was `111.94 Gbit/s` across `56/56` directed paths;
+- NCCL completed with wrong `0` and `23.8196 GB/s` average bus bandwidth; and
+- the debug canary recorded `824` `NET/IB` lines and zero `NET/Socket` lines.
+
+The concurrent outliers were classified as test-load contention only because the same paths passed the bounded serial rerun. They were not silently discarded.
+
+## What this work demonstrates
+
+The defensible result is not a single benchmark. It is the chain of evidence:
+
+1. prove identity;
+2. prove link and MTU;
+3. prove every directed rail path;
+4. prove RDMA transport;
+5. prove MPI launch;
+6. prove NCCL transport and correctness;
+7. repeat enough runs to freeze a profile; and
+8. rerun the chain after physical change.
+
+That is the engineering record preserved here.

--- a/docs/COMMISSIONING.md
+++ b/docs/COMMISSIONING.md
@@ -1,0 +1,75 @@
+# Identity-First Commissioning
+
+## Bring-up order
+
+The first Spark was commissioned on the management network before the high-speed fabric was connected. The same order became the fleet rule:
+
+1. Connect management Ethernet only.
+2. Allow `60-120` seconds for boot and network initialization.
+3. Identify the new lease and prove the hostname over SSH.
+4. Capture GPU, kernel, driver, firmware, service, and reboot-required state.
+5. Attach the physical label only after host identity is proven.
+6. Record the intended fabric role.
+7. Connect the high-speed fabric only after the management record is stable.
+
+The public alias table is in [sanitized-cluster-aliases.json](../examples/sanitized-cluster-aliases.json). It preserves relationships but is not deployment inventory.
+
+## Why the order mattered
+
+An early discovery pass exposed two NVIDIA systems that could have been confused: the newly attached Spark and an existing synchronization target. The correction was procedural, not cosmetic. A label, a remembered address, or an existing application entry could not establish identity by itself.
+
+For every system, the commissioning record required:
+
+- proved hostname;
+- management reachability;
+- SSH authorization;
+- GPU identity and driver result;
+- kernel and CUDA result;
+- failed-service count;
+- firmware state;
+- reboot-required state; and
+- intended fabric role.
+
+Hardware-address values and live switch ports are intentionally absent from this public adaptation.
+
+## First parity baseline
+
+The first four systems were normalized to the following recorded state:
+
+| Check | Recorded state |
+| --- | --- |
+| Operating system | Ubuntu `24.04.4` |
+| Kernel | `6.17.0-1021-nvidia` |
+| NVIDIA driver | `580.159.03` |
+| CUDA | `13.0` |
+| Failed services | `0` after correction |
+| Pending packages | `0` after correction |
+| Reboot required | no |
+| Firmware | current at the time of validation |
+
+One system needed the matching open NVIDIA kernel module. Another had a failed one-time service that was reset and rerun. Those were treated as parity failures until the same check passed again.
+
+## Management and fabric are separate gates
+
+The management plane exists to establish identity and launch bounded tests. It does not prove the RoCE data plane. Conversely, a fabric link does not prove that the management identity attached to it is the intended system.
+
+The public architecture uses:
+
+- `spark-a.example` through `spark-h.example` on `192.0.2.0/24` for management;
+- `198.51.100.0/24` for rail 0; and
+- `203.0.113.0/24` for rail 1.
+
+These are sanitized aliases. The real engineering rule is the important part: resolve a stable identity first, then verify the physical and logical fabric relationship independently.
+
+## Commissioning acceptance
+
+A system was ready for fabric work only when:
+
+- management identity was unambiguous;
+- SSH succeeded using the expected authorization path;
+- the NVIDIA GPU and driver were visible;
+- software versions matched the cohort;
+- failed-service and reboot-required checks were clear; and
+- the intended fabric interfaces could be tied back to that proved identity.
+
+If any one of those fields remained ambiguous, the work stopped before a topology or switch change.

--- a/docs/FABRIC-TROUBLESHOOTING.md
+++ b/docs/FABRIC-TROUBLESHOOTING.md
@@ -1,0 +1,123 @@
+# RoCE Fabric Troubleshooting Record
+
+## Baseline that failed
+
+The first four-system fabric looked healthy at the physical layer:
+
+- link speed reported `200000 Mb/s`;
+- MTU was `9000`; and
+- ordinary FEC and drop checks did not identify a clear physical fault.
+
+Useful throughput did not match:
+
+| Test | Recorded result |
+| --- | --- |
+| TCP | roughly `9.3-9.43 Gbit/s`, with retransmits |
+| Raw RDMA | roughly `0.1-7 Gbit/s` |
+| Reboot | no material correction |
+
+That result blocked NCCL performance conclusions. The underlay had not earned a workload benchmark yet.
+
+## RouterOS and QoS validation
+
+The CRS804-4DDQ was backed up and upgraded to RouterOS `7.23.1`. The source-backed RoCE shape used:
+
+- `200G-baseCR4`;
+- MTU `9000`;
+- DSCP `26` mapped to traffic class 3;
+- CNP `48` mapped to traffic class 6;
+- ECN on traffic class 3;
+- PFC on traffic class 3; and
+- a `100 Gbit/s` configured egress rate, the relevant RouterOS setting limit.
+
+Queue 3 counters increased and showed zero drops, but raw RDMA stayed near `5-7 Gbit/s` and TCP stayed near `8-9 Gbit/s` with retransmits. QoS classification was therefore functioning, but it was not the throughput root cause.
+
+Bounded cold-drain and PFC-bypass tests also failed to correct the path. They were rolled back rather than left as unexplained configuration drift.
+
+## Host and cable isolation
+
+MFT `4.35.0.159-1` reported both active functions at `200G x4`, Standard RS-FEC, with no observed issue. A direct cable between two Sparks removed the switch from the data path:
+
+| Direct test | Recorded result |
+| --- | ---: |
+| TCP | `12.8 Gbit/s`, no retransmits |
+| RDMA | `12.71 Gbit/s` |
+
+The direct path was better than the switched path but still below the intended per-rail gate. The conclusion was deliberately narrow: the switch worsened the symptom, while host-side limitations still required investigation.
+
+## Physical and logical correction
+
+The NVIDIA-aligned shape used the second ConnectX-7 port consistently on every Spark. It exposed two logical f1 functions:
+
+```text
+rail 0: enp1s0f1np1 / rocep1s0f1
+rail 1: enP2p1s0f1np1 / roceP2p1s0f1
+```
+
+Each rail used its own subnet. Sharing one subnet across both functions was rejected because it created route ambiguity and unreliable NCCL behavior.
+
+The physical change was followed by link, MTU, address, and directed-path checks before load testing.
+
+## Forwarding root cause
+
+The switch bridge host table and ARP state looked correct, but high-rate fabric traffic was being forwarded toward the switch CPU. The CPU queue accumulated drops instead of keeping the flow in the Marvell Prestera ASIC path.
+
+Before the repair:
+
+- TCP was roughly `9 Gbit/s` per half, with retransmits;
+- UDP receive was roughly `9.9 Gbit/s` with about `87%` loss; and
+- CPU-queue counters added roughly `16.9 million` dropped packets and about `152 GB` of dropped traffic.
+
+The repair added explicit destination-forwarding rules based on the live-learned fabric relationships. The public record omits destination identifiers and physical port numbers. The engineering change was:
+
+```text
+for each learned fabric destination:
+    match destination on the bridge data path
+    forward to the proved fabric egress
+    keep the flow in the switch ASIC
+```
+
+The rules were preceded by switch backup/export and carried a shared comment prefix so the complete change could be removed as one rollback.
+
+## Repair evidence
+
+| Test | Recorded result |
+| --- | ---: |
+| Repaired single path | `111.07 Gbit/s`, one retransmit |
+| Dual TCP pair A | `197.62 Gbit/s`, zero retransmits |
+| Dual TCP pair B | `198.00 Gbit/s`, zero retransmits |
+| Cross-pair TCP | `196.61 Gbit/s`, zero retransmits |
+| Sequential RDMA rail 0 | `97.98 Gbit/s` |
+| Sequential RDMA rail 1 | `97.98 Gbit/s` |
+
+This moved the failure classification away from FEC, MTU, cable link-up, and RDMA-device presence. The meaningful root cause was the forwarding path.
+
+## Recable regression
+
+A later physical rack recable changed which systems reached several fabric egresses. Four static forwarding destinations still pointed at the old relationship.
+
+The links remained at `200G-baseCR4` with `fec91`, and all expected fabric destinations were learned, but the stale static rules overrode the working physical state. The pre-fix small-packet matrix passed only `24/112` directed paths.
+
+After backup/export, only the stale forwarding destinations were corrected. The same acceptance program then passed:
+
+- small ping `112/112`;
+- jumbo ping `112/112`;
+- directed RDMA `112/112`;
+- RDMA range `109.06-109.30 Gbit/s`, mean `109.20 Gbit/s`;
+- MPI fanout `8/8`; and
+- all-eight NCCL canary and fixed-size collective.
+
+The lesson is operational: a physical recable invalidates static forwarding assumptions even when the links themselves stay green. Revalidation must include every directed path, not one representative pair.
+
+## Acceptance order
+
+1. Prove host identity over management.
+2. Prove both fabric interfaces, speed, FEC, and MTU.
+3. Prove small-packet reachability on every directed pair.
+4. Prove jumbo frames on every directed pair.
+5. Prove RDMA-CM on every directed pair and both rails.
+6. Prove MPI fanout.
+7. Prove NCCL uses `NET/IB`, has no `NET/Socket` fallback, and reports wrong `0`.
+8. Sweep for lingering test processes.
+
+Skipping an earlier gate makes a later benchmark ambiguous.

--- a/docs/NCCL-TUNING-RECORD.md
+++ b/docs/NCCL-TUNING-RECORD.md
@@ -1,0 +1,147 @@
+# NCCL Tuning Record
+
+## Prerequisite
+
+NCCL tuning started only after the dual-rail RoCE fabric passed directed connectivity and RDMA gates. The tuning record does not substitute for the underlay proof in [FABRIC-TROUBLESHOOTING.md](FABRIC-TROUBLESHOOTING.md).
+
+## Transport selection retained across profiles
+
+```text
+NCCL_IB_HCA=rocep1s0f1,roceP2p1s0f1
+NCCL_SOCKET_IFNAME=enp1s0f1np1,enP2p1s0f1np1
+UCX_NET_DEVICES=enp1s0f1np1,enP2p1s0f1np1
+NCCL_IB_DISABLE=0
+NCCL_NET_GDR_LEVEL=2
+```
+
+The public launcher aliases are documented in [nccl-profiles.json](../examples/nccl-profiles.json). They do not reproduce the live inventory.
+
+## Four-system profiles
+
+The two four-system cohorts converged on four QPs per connection, split data across QPs, and eight channels.
+
+### Cohort A
+
+```text
+NCCL_IB_QPS_PER_CONNECTION=4
+NCCL_IB_SPLIT_DATA_ON_QPS=1
+NCCL_MIN_NCHANNELS=8
+NCCL_MAX_NCHANNELS=8
+```
+
+Recorded `256 MiB` repeat set:
+
+| Metric | Average bus bandwidth |
+| --- | ---: |
+| Best observation | `23.8624 GB/s` |
+| Ten-run mean | `23.8246 GB/s` |
+| Ten-run median | `23.8226 GB/s` |
+| Ten-run range | `23.8068-23.8571 GB/s` |
+| Wrong | `0` |
+
+### Cohort B
+
+Cohort B used the same QP, split, and channel profile plus `NCCL_IGNORE_CPU_AFFINITY=1`.
+
+| Metric | Average bus bandwidth |
+| --- | ---: |
+| Ten-run mean | `23.8370 GB/s` |
+| Ten-run median | `23.8365 GB/s` |
+| Ten-run range | `23.8123-23.8720 GB/s` |
+| Wrong | `0` |
+
+The difference between cohorts was kept explicit rather than forcing one environment variable onto every group.
+
+## Eight-system profile
+
+The eight-system sweep favored a different shape:
+
+```text
+NCCL_IB_QPS_PER_CONNECTION=2
+NCCL_IB_SPLIT_DATA_ON_QPS=0
+NCCL_MIN_NCHANNELS=12
+NCCL_MAX_NCHANNELS=12
+```
+
+### Harness correction
+
+An early sweep attempted to use `env VAR=... ssh ...` to inject tuning values into the remote shell. That did not reliably propagate arbitrary variables. Those rows were retained privately but excluded from conclusions.
+
+Valid sweeps printed the remote `NCCL_` and `UCX_` environment before `mpirun`. That printout became part of the acceptance evidence for every tuning run.
+
+### Fixed 256 MiB result
+
+The pre-tuning repair proof was `21.7487 GB/s` average bus bandwidth at `256 MiB`, wrong `0`.
+
+The final profile used `50` iterations and `15` warmup iterations:
+
+| Run | Average bus bandwidth | Out-of-place | In-place | Wrong |
+| --- | ---: | ---: | ---: | ---: |
+| 1 | `22.9494 GB/s` | `22.14 GB/s` | `23.76 GB/s` | `0/0` |
+| 2 | `23.0400 GB/s` | `22.25 GB/s` | `23.83 GB/s` | `0/0` |
+| 3 | `23.0002 GB/s` | `22.18 GB/s` | `23.82 GB/s` | `0/0` |
+
+| Summary | Average bus bandwidth |
+| --- | ---: |
+| Mean | `22.9965 GB/s` |
+| Median | `23.0002 GB/s` |
+| Range | `22.9494-23.0400 GB/s` |
+
+That was about `5.7%` above the pre-tuning baseline.
+
+Two shorter observations reached `23.3216 GB/s` and `23.2391 GB/s`, both wrong `0`, but they were not frozen. The longer head-to-head set favored the twelve-channel profile for stability.
+
+### Size contour
+
+Wrong was `0` at every tested size.
+
+| Size | Out-of-place busbw | In-place busbw |
+| ---: | ---: | ---: |
+| `8 KiB` | `0.00 GB/s` | `0.09 GB/s` |
+| `16 KiB` | `0.20 GB/s` | `0.20 GB/s` |
+| `32 KiB` | `0.36 GB/s` | `0.35 GB/s` |
+| `64 KiB` | `0.77 GB/s` | `0.67 GB/s` |
+| `128 KiB` | `1.21 GB/s` | `1.38 GB/s` |
+| `256 KiB` | `1.52 GB/s` | `1.48 GB/s` |
+| `512 KiB` | `1.85 GB/s` | `1.76 GB/s` |
+| `1 MiB` | `4.68 GB/s` | `4.41 GB/s` |
+| `2 MiB` | `4.61 GB/s` | `4.74 GB/s` |
+| `4 MiB` | `5.45 GB/s` | `5.65 GB/s` |
+| `8 MiB` | `6.62 GB/s` | `6.67 GB/s` |
+| `16 MiB` | `7.19 GB/s` | `7.37 GB/s` |
+| `32 MiB` | `22.99 GB/s` | `22.85 GB/s` |
+| `64 MiB` | `23.33 GB/s` | `23.47 GB/s` |
+| `128 MiB` | `22.88 GB/s` | `22.93 GB/s` |
+| `256 MiB` | `23.73 GB/s` | `23.83 GB/s` |
+| `512 MiB` | `23.91 GB/s` | `23.88 GB/s` |
+| `1 GiB` | `24.14 GB/s` | `24.04 GB/s` |
+| `2 GiB` | `24.15 GB/s` | `24.23 GB/s` |
+| `4 GiB` | `24.26 GB/s` | `24.29 GB/s` |
+
+### Transport proof
+
+The final debug canary recorded:
+
+| Check | Result |
+| --- | ---: |
+| Exit code | `0` |
+| `Using network IB` | present |
+| `NET/IB` lines | `103` |
+| `NET/Socket` lines | `0` |
+| Connected rings | present |
+| Out-of-bounds values | `0 OK` |
+
+The tuned result therefore used RoCE/IB rather than socket fallback.
+
+## Findings that survived the sweep
+
+- The eight-system profile was not the four-system profile scaled up.
+- `NCCL_IGNORE_CPU_AFFINITY=1` did not help the eight-system finalist.
+- Forced `Tree/Simple` performed poorly at fixed `256 MiB`; default NCCL selection remained better among the tested choices.
+- A single rail produced about `13.39 GB/s` at fixed `256 MiB`; the tuned dual-rail profile reached the `23 GB/s` class.
+- At large messages, the tuned profile reached the `24 GB/s` class, with `24.26-24.29 GB/s` at `4 GiB`.
+- The post-run sweep found no lingering `mpirun`, `orted`, `all_reduce_perf`, `all_gather_perf`, or `ib_write_bw` processes beyond the check itself.
+
+## Parser
+
+[summarize_nccl_log.py](../scripts/summarize_nccl_log.py) extracts the fixed-size result rows and the reported average bus bandwidth from a local `nccl-tests` log. It does not connect to a cluster or claim that an input log came from this environment.

--- a/docs/POWER-BLE-COMMISSIONING.md
+++ b/docs/POWER-BLE-COMMISSIONING.md
@@ -1,0 +1,98 @@
+# Rack-Local BLE Power Commissioning
+
+## Objective
+
+The goal was to remove the mobile app from normal rack-local observation and eventually support guarded recovery through a Raspberry Pi 3B+. The design avoided vendor-cloud automation and internet-facing control endpoints.
+
+The public record preserves the commissioning method and conclusions. Bluetooth addresses, controller identifiers, UUIDs, payload bytes, raw captures, exact outlet maps, and device-to-outlet relationships remain private.
+
+## Local service shape
+
+The Raspberry Pi design used:
+
+- onboard BLE;
+- a dedicated service account;
+- local Unix sockets rather than a TCP listener;
+- append-only actuation receipts;
+- a read-only commissioning mode;
+- maintenance and scheduler gates; and
+- remote supervision that was not required for local process continuity.
+
+The vendor app remained break-glass tooling for firmware, pairing, and restoring a known physical state.
+
+## Clean-room characterization
+
+The BLE work was performed by observing local controller behavior and bounded app-generated state transitions. The vendor application was not decompiled, and vendor cloud endpoints were not used.
+
+The work established:
+
+- repeatable controller discovery;
+- a metadata-only GATT inventory;
+- a request/response message family with sequence and selector correlation;
+- CRC validation; and
+- an identity-verified app-free read path.
+
+One read-only capture collected `415` observations around a `27` byte advertised payload. A later bounded capture collected `60` frames across four payload groups. Those counts helped isolate stable and varying fields, but no raw frame data is published here.
+
+## The first failure stopped the write path
+
+An early one-outlet test received a valid protocol acknowledgement but moved a different physical relay than the requested target. The official app restored the known baseline, the helper was quarantined, and relay writes stopped.
+
+That event changed the acceptance rule:
+
+> A valid protocol acknowledgement proves only that the controller accepted a message. It does not prove target identity, relay mapping, or physical state.
+
+## The second correction was more fundamental
+
+The first decoder treated a field in a GET response as physical relay state. A later physical observation disproved it: the controller could report a continuous-ON program while the outlet indicator was dark and the attached load was not running.
+
+The field was reclassified as configured program mode, not relay state.
+
+The daemon behavior was corrected to:
+
+- report physical relay state as unknown unless a separate correlated source proves it;
+- preserve unknown sensor and alarm fields as null;
+- reject production relay writes before they reach the controller;
+- keep the scheduler disabled; and
+- keep unattended recovery disabled.
+
+The correction passed Ruff and `199` tests in the private implementation. The deployed verification produced zero relay writes.
+
+## What the app-free path proved
+
+With the app closed, the Pi could establish a local read path that validated:
+
+- controller identity;
+- framing;
+- CRC;
+- sequence correlation; and
+- selector correlation.
+
+That is a useful result, but it is not a physical relay-state decoder.
+
+## What remains deliberately unclaimed
+
+- app-free physical relay readback;
+- a complete, proven controller-to-relay mapping;
+- temperature and alarm decoding;
+- unattended Spark recovery; and
+- production temperature-driven fan switching.
+
+The work is substantive because it caught the unsafe assumption before it became automation. Fail-closed is the correct commissioning outcome when software state and physical observation disagree.
+
+## Re-entry gate for future actuator work
+
+Any future write path must begin on an empty reserve outlet and pass all of the following under direct physical observation:
+
+1. identity-verified controller selection;
+2. known OFF physical state;
+3. OFF readback correlation;
+4. one bounded ON transition;
+5. visible physical ON confirmation;
+6. independent readback confirmation;
+7. one bounded OFF transition;
+8. visible physical OFF confirmation;
+9. restart and persistence checks; and
+10. proof that no other outlet changed.
+
+Until those gates pass repeatedly, reads remain informational and writes remain disabled.

--- a/docs/PUBLICATION-SAFETY.md
+++ b/docs/PUBLICATION-SAFETY.md
@@ -1,30 +1,46 @@
 # Publication Safety
 
-## Purpose
+## What this repository preserves
 
-I use this repository to publish the cluster engineering method, not the cluster. Every example must remain synthetic and non-operational.
+This is a sanitized adaptation of real DGX Cluster engineering work. Non-identifying measurements, software versions, failure modes, decisions, rollback logic, and acceptance results are retained. They are not invented examples and they are not rewritten as generic portfolio claims.
 
-## Allowed
+## What is replaced
 
-- Fictional names under the example namespaces.
-- Documentation-only address ranges.
-- General validation and reliability patterns.
-- Synthetic JSON with clearly labeled illustrative outcomes.
-- Limitations and failed assumptions that do not identify a live environment.
+- Live IP addresses and subnets are mapped consistently into RFC 5737 documentation ranges.
+- Private hostnames are mapped to `spark-a.example` through `spark-h.example` and other `.example` aliases.
+- Physical switch-port labels are replaced by role relationships rather than live numbering.
+- Exact power outlet and controller maps are omitted.
+- Usernames, email addresses, account identifiers, hardware identifiers, serial values, and local paths are omitted.
+- Private endpoints, overlay addresses, raw captures, credentials, keys, tokens, and secrets are omitted.
 
-## Excluded
+## What is intentionally not generalized
 
-- Live network or hardware identity.
-- Accounts, credentials, keys, tokens, and local paths.
-- Raw logs, telemetry, inventories, service listings, and equipment maps.
-- Exact system counts, operational measurements, and current status.
-- Screenshots, photos, or copied private artifacts.
-- Commands aimed at real systems.
+The repository retains technical facts that make the work defensible, including:
 
-## Project-specific review
+- software and firmware versions;
+- interface and transport names;
+- switch model and operating-system version;
+- measured throughput and correctness results;
+- failed hypotheses and negative tests;
+- acceptance and stop conditions; and
+- the commissioning conclusion when automation remained disabled.
 
-Cluster material must not reveal how private roles connect, how many systems exist, or which services share a dependency. Architecture examples describe a validation pattern only.
+## Alias convention
 
-## Gate
+The public aliases are internally consistent but non-operational:
 
-The standard-library checker validates required files, JSON syntax, Mermaid-only architecture, and common private-data patterns. CI runs the same gate. A passing scan reduces publication risk but does not replace human review.
+| Role | Public convention |
+| --- | --- |
+| Management plane | `192.0.2.0/24` |
+| RoCE rail 0 | `198.51.100.0/24` |
+| RoCE rail 1 | `203.0.113.0/24` |
+| Compute systems | `spark-a.example` through `spark-h.example` |
+| Fabric switch | `fabric-switch.example` |
+
+The addresses are reserved for documentation and do not identify the live environment.
+
+## Automated gate
+
+The publication checker rejects common secret patterns, private and CGNAT addresses, multicast-local hostnames, email addresses, hardware-address formats, UUIDs, personal home paths, raw controller-map fields, and links to private source repositories. It also validates JSON, relative Markdown links, the Mermaid-only architecture file, and required repository structure.
+
+The checker is a backstop, not a substitute for reviewing whether a technically valid detail would expose a live control relationship.

--- a/docs/RACK-RECABLE-REVALIDATION.md
+++ b/docs/RACK-RECABLE-REVALIDATION.md
@@ -1,0 +1,90 @@
+# Rack Recable and Full Fabric Revalidation
+
+## Why this record exists
+
+A known-good fabric was physically torn down and rebuilt. The old benchmark results could not prove the new physical state. The acceptance program was rerun from management identity through NCCL transport.
+
+Public aliases replace live hostnames, addresses, and port numbers. The measured results are retained.
+
+## First recable repair
+
+The first rack recable left four static switch forwarding destinations pointed at their former physical egresses. All eight physical links were up at `200G-baseCR4` with `fec91`, and all sixteen logical fabric destinations were learned. The stale static rules still stranded four systems.
+
+Pre-fix evidence:
+
+| Gate | Result |
+| --- | ---: |
+| Small directed ping matrix | `24/112` pass |
+| Reachable clique | four systems |
+| Affected systems | four systems |
+
+The switch was backed up and exported. Only the stale destination relationships were changed; already-correct rules stayed untouched.
+
+Post-fix evidence:
+
+| Gate | Result |
+| --- | ---: |
+| Small ping, both rails, every ordered pair | `112/112` |
+| Jumbo ping with `8972` byte payload and do-not-fragment | `112/112` |
+| Directed RDMA, both rails, every ordered pair | `112/112` |
+| RDMA bandwidth range | `109.06-109.30 Gbit/s` |
+| RDMA mean | `109.20 Gbit/s` |
+| MPI fanout | `8/8` |
+| NCCL `1 MiB` canary | pass |
+| NCCL fixed `256 MiB` | pass |
+
+The fixed-size collective completed with:
+
+- out-of-bounds values `0 OK`;
+- out-of-place bus bandwidth `18.53 GB/s`;
+- in-place bus bandwidth `21.71 GB/s`; and
+- average bus bandwidth `20.1189 GB/s`.
+
+That was a repair baseline, not a peak claim.
+
+## Later topology rerun
+
+After another rack teardown and reassembly, the full observed topology was checked again.
+
+### Management and interface state
+
+- management SSH passed on all eight systems;
+- all sixteen f1 interfaces were up;
+- each reported `200000 Mb/s`; and
+- MTU was `9000`.
+
+### Packet and RDMA gates
+
+| Gate | Result |
+| --- | ---: |
+| Jumbo directed ping | `112/112` |
+| Concurrent directed RDMA | `105/112` above the `90 Gbit/s` gate |
+| Bounded serial retry of seven outliers | all passed at `111.85 Gbit/s` |
+| Secondary rail | `56/56`, mean `111.94 Gbit/s` |
+
+The seven concurrent outliers were classified as test-load contention only after each exact path passed the bounded serial rerun. The first result was not overwritten or described as a full concurrent pass.
+
+### NCCL gate
+
+| Check | Result |
+| --- | ---: |
+| Fixed `256 MiB` run | exit `0` |
+| Wrong | `0` |
+| Average bus bandwidth | `23.8196 GB/s` |
+| Debug `NET/IB` lines | `824` |
+| Debug `NET/Socket` lines | `0` |
+
+The process sweep found no lingering benchmark or RDMA test jobs.
+
+## Acceptance logic
+
+The topology was accepted because:
+
+1. identity and management access passed across the complete cohort;
+2. both logical rails were present at the expected speed and MTU;
+3. every jumbo directed path passed;
+4. every RDMA outlier from the concurrent sweep passed a bounded same-path retry;
+5. NCCL completed with correct results over `NET/IB` and no socket fallback; and
+6. the test environment was left clean.
+
+The acceptance does not mean every simultaneous all-to-all RDMA path exceeded the gate in one concurrent pass. That distinction remains explicit.

--- a/docs/RECOVERY-POLICY.md
+++ b/docs/RECOVERY-POLICY.md
@@ -1,0 +1,80 @@
+# Guarded Spark Recovery Policy
+
+## Separation of duties
+
+Triage decides whether a failure is isolated and eligible. Actuation performs one bounded recovery. They are separate operations with separate receipts.
+
+The public aliases describe the policy without exposing the live power map. Infrastructure roles are never eligible for recovery.
+
+## Historical eligibility gate
+
+A Spark was eligible for a recovery decision only when all of the following were true:
+
+- LAN ping failed;
+- LAN SSH and hostname proof failed;
+- overlay reachability failed;
+- the same isolated failure appeared in three consecutive five-minute observations;
+- exactly one Spark was fully failed;
+- at least six peers were healthy;
+- maintenance pause was clear;
+- controller alarm state was clear;
+- the temperature safety gate was clear;
+- the node was outside its six-hour recovery cooldown; and
+- the private identity-to-outlet mapping digest matched the current decision.
+
+Any unknown, stale, mismatched, or shared failure produced a refusal.
+
+## Decision receipt
+
+An eligible plan produced a single-use decision valid for `60` seconds. The receipt bound:
+
+- the sanitized logical node role;
+- private controller and outlet identity by digest, not by public label;
+- the observation set;
+- every policy reason;
+- the cooldown state;
+- a unique operation identifier; and
+- the mapping version.
+
+Stale, replayed, or mapping-mismatched decisions were rejected.
+
+## Bounded actuation design
+
+The intended operation was:
+
+1. acquire per-node and global locks;
+2. take a fresh controller snapshot;
+3. rerun the fleet probes;
+4. journal the intent before relay OFF;
+5. switch the proved compute outlet OFF;
+6. verify OFF;
+7. wait `20` seconds;
+8. restore continuous ON;
+9. verify ON; and
+10. allow up to eight minutes for the system to return before closing the receipt.
+
+There was no retry loop. If the outlet was already unexpectedly OFF, the design restored ON without adding another OFF interval.
+
+After a daemon restart during an interrupted operation, only the journaled, identity-verified compute outlet could be restored to continuous ON. The daemon could not initiate a second cycle during recovery.
+
+## Hard refusals
+
+The policy refused recovery for:
+
+- infrastructure roles;
+- more than one failed Spark;
+- shared network or power symptoms;
+- hostname or mapping mismatch;
+- active maintenance;
+- high or unknown temperature;
+- controller alarm or unknown alarm state;
+- cooldown;
+- stale evidence;
+- replayed decisions; and
+- ambiguous physical relay state.
+
+Overload remained a physical-reset condition because software control is unavailable during controller overload.
+
+## Current conclusion
+
+The policy engine and refusal logic remain useful engineering artifacts. Unattended relay recovery is not claimed as enabled because BLE physical relay-state verification did not pass commissioning. The correct runtime state is fail-closed.

--- a/docs/SHARE.md
+++ b/docs/SHARE.md
@@ -2,26 +2,38 @@
 
 ## Short post
 
-I turned my local AI cluster work into a public-safe engineering record. The useful part is not my topology. It is the discipline: identity before action, evidence before change, rollback before risk, and clear limits on every claim.
+I rebuilt my DGX Cluster public repo around the work itself: the slow underlay, the switch forwarding root cause, the dual-rail repair, the NCCL tuning, the recable failure, and the validation that followed. The measurements are real. The live identities and topology are not published.
 
-## Thread-style post
+## Thread draft
 
-**Opening**
+### 1
 
-I have been documenting the engineering method behind my local AI infrastructure without publishing the environment itself.
+I wanted the public DGX Cluster repo to show the actual engineering, not a generic description of a lab.
 
-**What I built**
+### 2
 
-A compact public framework for readiness checks, layered observability, bounded experiments, rollback, and evidence receipts.
+The first important result was a failure: `200G` links and MTU `9000`, but only about `9.3-9.43 Gbit/s` TCP and roughly `0.1-7 Gbit/s` RDMA. I stopped before using NCCL as a fabric conclusion.
 
-**What changed in my thinking**
+### 3
 
-Reachability is not workload health. One fast run is not repeatability. A repair is not complete until the acceptance check and rollback are documented.
+The usual suspects did not explain it. QoS counters moved, FEC and link diagnostics were clean, and a direct cable improved the symptom without reaching the intended per-rail gate.
 
-**How I kept it safe**
+### 4
 
-Every host and address is synthetic. The repository has an automated privacy gate and contains no live inventory, telemetry, equipment map, or operational target.
+The root cause was the switch forwarding path. High-rate fabric traffic was being sent toward the switch CPU and dropped. Moving the learned destinations back to the ASIC path produced `111.07 Gbit/s`, then roughly `197-198 Gbit/s` across paired TCP tests.
 
-**Bottom line**
+### 5
 
-The portfolio is about making infrastructure work explainable and repeatable, including the failures and unknowns.
+After a rack recable, stale forwarding destinations broke four systems even though every physical link looked healthy. The rerun went from `24/112` directed pings to full small-packet, jumbo, and directed-RDMA coverage.
+
+### 6
+
+Only after the underlay was valid did I freeze the all-eight NCCL profile. Three longer `256 MiB` repeats averaged `22.9965 GB/s`, wrong `0`, with `NET/IB` and no socket fallback.
+
+### 7
+
+I also included the power/BLE commissioning failure that mattered: a valid acknowledgement moved the wrong relay, and a later physical check proved the supposed relay-state field was only program mode. Automation stayed fail-closed.
+
+### 8
+
+Everything public uses documentation addresses and stable aliases. The technical decisions and measurements remain; the live topology, control map, accounts, and raw captures do not.

--- a/docs/SOURCE-ADAPTATION.md
+++ b/docs/SOURCE-ADAPTATION.md
@@ -1,0 +1,59 @@
+# Source Adaptation Map
+
+## Purpose
+
+This file records how the public repository was rebuilt from the private DGX Cluster engineering record. It is a coverage and privacy check, not a link to private material.
+
+## Preserved source categories
+
+| Source category | Public destination | Preserved substance |
+| --- | --- | --- |
+| First-system bring-up and connection record | [COMMISSIONING.md](COMMISSIONING.md) | management-first order, identity ambiguity, parity gates, recorded versions |
+| Four-system baseline and RoCE validation | [FABRIC-TROUBLESHOOTING.md](FABRIC-TROUBLESHOOTING.md) | failed throughput, QoS and FEC tests, direct-cable isolation, stop conditions |
+| Known-good topology delta and physical correction | [CASE-STUDY.md](CASE-STUDY.md), [FABRIC-TROUBLESHOOTING.md](FABRIC-TROUBLESHOOTING.md) | second-port dual-function shape, separate rail subnets, physical-action gate |
+| CRS804 forwarding repair | [FABRIC-TROUBLESHOOTING.md](FABRIC-TROUBLESHOOTING.md) | CPU-drop diagnosis, ASIC-forwarding correction, rollback design, measured repair results |
+| Four-system and eight-system NCCL campaigns | [NCCL-TUNING-RECORD.md](NCCL-TUNING-RECORD.md) | frozen profiles, harness correction, repeat statistics, size contour, transport proof |
+| Rack recable repair and later full rerun | [RACK-RECABLE-REVALIDATION.md](RACK-RECABLE-REVALIDATION.md) | stale forwarding relationship, complete directed matrices, bounded retry classification, NCCL proof |
+| Guarded recovery design | [RECOVERY-POLICY.md](RECOVERY-POLICY.md) | multi-signal eligibility, refusal logic, cooldown, single-use decision, recovery journal |
+| Raspberry Pi BLE commissioning | [POWER-BLE-COMMISSIONING.md](POWER-BLE-COMMISSIONING.md) | clean-room method, acknowledgement failure, decoder correction, fail-closed result |
+| Open-rack thermal walkthrough | [THERMAL-MANAGEMENT.md](THERMAL-MANAGEMENT.md) | raised power supplies, upward fan design, planned test, explicit deferred result |
+
+## Sanitized categories
+
+The adaptation consistently replaces or omits:
+
+- live management, rail, and overlay addresses;
+- live hostnames and private service names;
+- usernames, emails, personal names beyond the public brand, and local paths;
+- hardware addresses, serials, device identifiers, and account identifiers;
+- credentials, keys, tokens, and secrets;
+- private URLs and endpoints;
+- raw BLE addresses, UUIDs, frames, payload bytes, and controller fingerprints;
+- exact physical switch-port labels; and
+- exact controller, outlet, and load mappings.
+
+## Stable public relationships
+
+The public record uses one stable alias set throughout:
+
+- compute: `spark-a.example` through `spark-h.example`;
+- management: `192.0.2.21` through `192.0.2.28`;
+- rail 0: `198.51.100.21` through `198.51.100.28`;
+- rail 1: `203.0.113.21` through `203.0.113.28`; and
+- switch: `fabric-switch.example`.
+
+These names and addresses are explicitly sanitized public aliases. The measurements, versions, decisions, and troubleshooting outcomes around them are the recorded engineering work.
+
+## Excluded source categories
+
+The public cluster record does not import:
+
+- raw evidence directories or logs;
+- private inventory and topology manifests;
+- screenshots or rack photos;
+- controller captures or live power maps;
+- unrelated training corpora and model artifacts;
+- active monitoring state; or
+- current operational status.
+
+Those exclusions reduce exposure without replacing the engineering narrative with generic prose.

--- a/docs/THERMAL-MANAGEMENT.md
+++ b/docs/THERMAL-MANAGEMENT.md
@@ -1,0 +1,55 @@
+# Open-Rack Thermal Management
+
+## Design
+
+The rack was left open deliberately. Access to the Sparks, power supplies, cables, and fabric mattered more than presenting a sealed cabinet.
+
+The lower rack area initially concentrated power bricks and cable loops near the floor. The response had two parts:
+
+1. raise and organize the power supplies in printed rack supports; and
+2. place a small floor fan in front of the rack, aimed upward through the open shelves.
+
+Raising the bricks improved service access and removed a dense pile from the lowest warm pocket. The fan was intended to break up stagnant air and move room air upward through the rack.
+
+This was not a CFM measurement, an airflow calibration, or a sealed-system cooling design.
+
+## Control separation
+
+The fan had its own addressable environmental outlet. Compute and infrastructure loads remained continuous-power roles and were not attached to temperature programs.
+
+The design boundary was intentional:
+
+- the environmental outlet could be commissioned independently;
+- Spark power behavior could not be triggered by rack temperature;
+- infrastructure outlets were excluded from testing; and
+- a missing sensor value or alarm would resolve to fan ON, not fan OFF.
+
+Exact controller and outlet labels are omitted from the public record.
+
+## Planned differential test
+
+The short test plan was:
+
+1. hold the Spark workload state as steady as practical;
+2. record the single rack probe's starting temperature and humidity;
+3. switch only the fan OFF and physically verify it stopped;
+4. sample the same probe at a fixed interval for a short baseline window;
+5. switch only the fan ON and physically verify it ran;
+6. sample for the same duration; and
+7. compare the OFF and ON averages, ranges, and timestamps.
+
+Spark internal temperature and rack-probe temperature were kept separate. The former was a workload indicator in Celsius; the latter was the rack-environment observation in Fahrenheit.
+
+## Recorded outcome
+
+The differential test was deferred. The owner chose to keep the fan continuously ON, and the controller telemetry read path was intermittent. No threshold was changed and no complete, matched OFF/ON data set was captured.
+
+Therefore this repository does not claim:
+
+- a measured cooling delta;
+- automatic temperature control;
+- a proven hysteresis rule;
+- long-term thermal capacity; or
+- a maximum safe workload temperature for the room or rack.
+
+The defensible result is narrower: the power supplies were raised, the open-rack airflow path was improved, and a dedicated fan was positioned to move room air upward. The intended measurement method is documented, but the result remains unknown.

--- a/examples/nccl-profiles.json
+++ b/examples/nccl-profiles.json
@@ -1,0 +1,48 @@
+{
+  "schema_version": "recorded-nccl-profiles-v1",
+  "sanitized_public_example": true,
+  "notice": "Tuning values and measurements are retained from the engineering record. Hosts and addresses are sanitized public aliases.",
+  "transport": {
+    "NCCL_IB_HCA": "rocep1s0f1,roceP2p1s0f1",
+    "NCCL_SOCKET_IFNAME": "enp1s0f1np1,enP2p1s0f1np1",
+    "UCX_NET_DEVICES": "enp1s0f1np1,enP2p1s0f1np1",
+    "NCCL_IB_DISABLE": "0",
+    "NCCL_NET_GDR_LEVEL": "2"
+  },
+  "four_system_profile": {
+    "NCCL_IB_QPS_PER_CONNECTION": "4",
+    "NCCL_IB_SPLIT_DATA_ON_QPS": "1",
+    "NCCL_MIN_NCHANNELS": "8",
+    "NCCL_MAX_NCHANNELS": "8"
+  },
+  "eight_system_profile": {
+    "NCCL_IB_QPS_PER_CONNECTION": "2",
+    "NCCL_IB_SPLIT_DATA_ON_QPS": "0",
+    "NCCL_MIN_NCHANNELS": "12",
+    "NCCL_MAX_NCHANNELS": "12"
+  },
+  "sanitized_launcher": {
+    "hostname": "spark-e.example",
+    "management_address": "192.0.2.25",
+    "members": [
+      "spark-a.example",
+      "spark-b.example",
+      "spark-c.example",
+      "spark-d.example",
+      "spark-e.example",
+      "spark-f.example",
+      "spark-g.example",
+      "spark-h.example"
+    ]
+  },
+  "recorded_eight_system_256_mib": {
+    "runs_gb_per_second": [
+      22.9494,
+      23.04,
+      23.0002
+    ],
+    "mean_gb_per_second": 22.9965,
+    "median_gb_per_second": 23.0002,
+    "wrong": 0
+  }
+}

--- a/examples/recovery-policy.json
+++ b/examples/recovery-policy.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": "guarded-recovery-policy-v1",
+  "sanitized_public_example": true,
+  "notice": "This policy shape omits private controller and outlet identities. It is not an enabled actuator configuration.",
+  "eligibility": {
+    "consecutive_failures": 3,
+    "observation_interval_seconds": 300,
+    "exactly_one_failed_compute_role": true,
+    "minimum_healthy_peers": 6,
+    "maintenance_must_be_clear": true,
+    "alarm_must_be_clear": true,
+    "temperature_gate_must_be_clear": true,
+    "cooldown_seconds": 21600,
+    "identity_mapping_digest_must_match": true
+  },
+  "decision": {
+    "single_use": true,
+    "valid_for_seconds": 60,
+    "replay_rejected": true,
+    "stale_evidence_rejected": true
+  },
+  "bounded_operation": {
+    "off_interval_seconds": 20,
+    "return_window_seconds": 480,
+    "retry_loop": false,
+    "journal_before_off": true,
+    "verify_before_and_after": true
+  },
+  "hard_denials": [
+    "infrastructure_role",
+    "shared_failure",
+    "identity_mismatch",
+    "unknown_temperature",
+    "unknown_alarm",
+    "ambiguous_relay_state"
+  ],
+  "current_status": "fail_closed_no_unattended_actuation"
+}

--- a/examples/sanitized-cluster-aliases.json
+++ b/examples/sanitized-cluster-aliases.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "sanitized-alias-map-v1",
+  "sanitized_public_example": true,
+  "notice": "These RFC 5737 addresses and .example names preserve engineering relationships but do not reproduce live inventory.",
+  "fabric_switch": "fabric-switch.example",
+  "systems": [
+    {
+      "alias": "spark-a.example",
+      "management": "192.0.2.21",
+      "rail_0": "198.51.100.21",
+      "rail_1": "203.0.113.21"
+    },
+    {
+      "alias": "spark-b.example",
+      "management": "192.0.2.22",
+      "rail_0": "198.51.100.22",
+      "rail_1": "203.0.113.22"
+    },
+    {
+      "alias": "spark-c.example",
+      "management": "192.0.2.23",
+      "rail_0": "198.51.100.23",
+      "rail_1": "203.0.113.23"
+    },
+    {
+      "alias": "spark-d.example",
+      "management": "192.0.2.24",
+      "rail_0": "198.51.100.24",
+      "rail_1": "203.0.113.24"
+    },
+    {
+      "alias": "spark-e.example",
+      "management": "192.0.2.25",
+      "rail_0": "198.51.100.25",
+      "rail_1": "203.0.113.25"
+    },
+    {
+      "alias": "spark-f.example",
+      "management": "192.0.2.26",
+      "rail_0": "198.51.100.26",
+      "rail_1": "203.0.113.26"
+    },
+    {
+      "alias": "spark-g.example",
+      "management": "192.0.2.27",
+      "rail_0": "198.51.100.27",
+      "rail_1": "203.0.113.27"
+    },
+    {
+      "alias": "spark-h.example",
+      "management": "192.0.2.28",
+      "rail_0": "198.51.100.28",
+      "rail_1": "203.0.113.28"
+    }
+  ],
+  "interfaces": {
+    "rail_0_netdev": "enp1s0f1np1",
+    "rail_0_rdma": "rocep1s0f1",
+    "rail_1_netdev": "enP2p1s0f1np1",
+    "rail_1_rdma": "roceP2p1s0f1"
+  }
+}

--- a/examples/synthetic-cluster-observation.json
+++ b/examples/synthetic-cluster-observation.json
@@ -1,46 +1,37 @@
 {
-  "schema_version": "public-example-v1",
-  "synthetic": true,
-  "purpose": "Demonstrate a layered cluster observation receipt without reproducing a live environment.",
+  "schema_version": "public-alias-observation-v2",
+  "sanitized_public_example": true,
+  "compatibility_note": "This path is retained for existing public links. The identities and addresses are documentation-only aliases.",
   "subject": {
-    "role": "representative_compute",
-    "hostname": "compute-a.example",
-    "address": "192.0.2.10"
-  },
-  "intent": {
-    "operation": "read_only_validation",
-    "acceptance": "All declared gates have current evidence and no unresolved identity mismatch."
+    "hostname": "spark-a.example",
+    "management_address": "192.0.2.21",
+    "rail_0_address": "198.51.100.21",
+    "rail_1_address": "203.0.113.21"
   },
   "gates": [
     {
       "name": "identity",
-      "result": "pass",
-      "evidence_class": "synthetic"
+      "result": "pass"
     },
     {
       "name": "management_reachability",
-      "result": "pass",
-      "evidence_class": "synthetic"
+      "result": "pass"
     },
     {
-      "name": "transport_readiness",
-      "result": "unknown",
-      "evidence_class": "not_collected"
+      "name": "physical_link",
+      "result": "pass"
     },
     {
-      "name": "workload_health",
-      "result": "unknown",
-      "evidence_class": "not_collected"
+      "name": "directed_rdma",
+      "result": "not_collected"
+    },
+    {
+      "name": "nccl_transport",
+      "result": "not_collected"
     }
   ],
   "decision": {
     "status": "not_accepted",
-    "reason": "Dependent evidence remains unknown.",
-    "next_step": "Collect the missing read-only evidence or stop."
-  },
-  "limitations": [
-    "Illustrative data only.",
-    "No live command was run.",
-    "No operational result is claimed."
-  ]
+    "reason": "The public example intentionally leaves workload gates uncollected."
+  }
 }

--- a/scripts/check_publication_safety.py
+++ b/scripts/check_publication_safety.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Fail closed when public repository text contains likely private data."""
+"""Fail closed when the public engineering record contains private data."""
 
 from __future__ import annotations
 
@@ -14,21 +14,42 @@ SELF = Path("scripts/check_publication_safety.py")
 FENCE = chr(96) * 3
 REQUIRED_FILES = {
     Path("README.md"),
-    Path("docs/CASE-STUDY.md"),
     Path("docs/ARCHITECTURE.md"),
+    Path("docs/CASE-STUDY.md"),
+    Path("docs/COMMISSIONING.md"),
+    Path("docs/FABRIC-TROUBLESHOOTING.md"),
+    Path("docs/NCCL-TUNING-RECORD.md"),
+    Path("docs/POWER-BLE-COMMISSIONING.md"),
     Path("docs/PUBLICATION-SAFETY.md"),
+    Path("docs/RACK-RECABLE-REVALIDATION.md"),
+    Path("docs/RECOVERY-POLICY.md"),
     Path("docs/SHARE.md"),
+    Path("docs/SOURCE-ADAPTATION.md"),
+    Path("docs/THERMAL-MANAGEMENT.md"),
+    Path("examples/nccl-profiles.json"),
+    Path("examples/recovery-policy.json"),
+    Path("examples/sanitized-cluster-aliases.json"),
+    Path("scripts/summarize_nccl_log.py"),
     Path(".github/workflows/publication-safety.yml"),
     SELF,
 }
 TEXT_SUFFIXES = {".md", ".json", ".py", ".yml", ".yaml", ".txt", ".toml"}
 FORBIDDEN_NETWORKS = tuple(
     ipaddress.ip_network(value)
-    for value in ("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "100.64.0.0/10")
+    for value in (
+        "10.0.0.0/8",
+        "172.16.0.0/12",
+        "192.168.0.0/16",
+        "100.64.0.0/10",
+    )
 )
 ALLOWED_DOCUMENTATION_NETWORKS = tuple(
     ipaddress.ip_network(value)
-    for value in ("192.0.2.0/24", "198.51.100.0/24", "203.0.113.0/24")
+    for value in (
+        "192.0.2.0/24",
+        "198.51.100.0/24",
+        "203.0.113.0/24",
+    )
 )
 IPV4 = re.compile(r"(?<![0-9])(?:[0-9]{1,3}\.){3}[0-9]{1,3}(?![0-9])")
 PATTERNS = {
@@ -38,19 +59,25 @@ PATTERNS = {
     "slack_token": re.compile(r"\bxox[baprs]-[A-Za-z0-9-]+\b"),
     "email": re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b"),
     "mac_address": re.compile(r"\b(?:[0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}\b"),
-    "uuid": re.compile(r"\b[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}\b"),
-    "serial_like": re.compile(r"\b(?=[A-Z0-9]*[A-Z])(?=[A-Z0-9]*[0-9])[A-Z0-9]{10,}\b"),
+    "uuid": re.compile(
+        r"\b[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-"
+        r"[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}\b"
+    ),
     "multicast_local_hostname": re.compile(r"\b[A-Za-z0-9-]+[.]local\b", re.IGNORECASE),
+    "tailscale_endpoint": re.compile(r"\b[A-Za-z0-9.-]+[.]ts[.]net\b", re.IGNORECASE),
     "mac_home_path": re.compile(r"/Users/[A-Za-z0-9._-]+"),
     "posix_home_path": re.compile(r"/home/[A-Za-z0-9._-]+"),
     "windows_home_path": re.compile(r"[A-Za-z]:\\Users\\[^\\\s]+"),
     "secret_assignment": re.compile(
-        r"""(?i)\b(?:api[_-]?key|password|secret|access[_-]?token)\b\s*[:=]\s*["'][^"']+["']"""
+        r'''(?i)\b(?:api[_-]?key|password|secret|access[_-]?token)\b\s*[:=]\s*["'][^"']+["']'''
     ),
-    "sensitive_mapping_field": re.compile(
-        r"""(?i)["']?(?:device_id|hardware_id|serial_number|mac_address|outlet_map|controller_map|live_topology|service_inventory)["']?\s*[:=]"""
+    "live_mapping_field": re.compile(
+        r'''(?i)["']?(?:device_id|hardware_id|serial_number|mac_address|outlet_map|controller_map|live_topology|service_inventory)["']?\s*[:=]'''
     ),
-    "private_source_link": re.compile(r"https://github[.]com/GumbiiDigital/(?![A-Za-z0-9._-]+-public(?:\b|/))"),
+    "private_source_link": re.compile(
+        r"https://github[.]com/GumbiiDigital/(?![A-Za-z0-9._-]+-public(?:\b|/))"
+    ),
+    "raw_switch_port": re.compile(r"\bqsfp[0-9A-Za-z-]*-[0-9]+-[0-9]+\b", re.IGNORECASE),
     "markdown_image": re.compile(r"!\[[^]]*\]\([^)]+\)"),
 }
 LINK = re.compile(r"(?<!!)\[[^]]+\]\(([^)]+)\)")
@@ -77,6 +104,9 @@ def scan_text(relative: Path, text: str, failures: list[str]) -> None:
 
     for match in IPV4.finditer(text):
         value = match.group(0)
+        context = text[max(0, match.start() - 12) : match.end() + 2]
+        if value == "4.35.0.159" and "MFT" in context and context.endswith("-1"):
+            continue
         try:
             address = ipaddress.ip_address(value)
         except ValueError:
@@ -94,8 +124,15 @@ def scan_text(relative: Path, text: str, failures: list[str]) -> None:
         if relative == Path("docs/ARCHITECTURE.md"):
             lines = [line for line in text.splitlines() if line.strip()]
             fence_lines = [line for line in lines if line.startswith(FENCE)]
-            if not lines or lines[0] != f"{FENCE}mermaid" or lines[-1] != FENCE or len(fence_lines) != 2:
-                failures.append(f"{relative}: architecture must contain one Mermaid fence and no prose")
+            if (
+                not lines
+                or lines[0] != f"{FENCE}mermaid"
+                or lines[-1] != FENCE
+                or len(fence_lines) != 2
+            ):
+                failures.append(
+                    f"{relative}: architecture must contain one Mermaid fence and no prose"
+                )
         elif not first.startswith("#"):
             failures.append(f"{relative}: first non-empty line must be a heading")
 
@@ -119,14 +156,19 @@ def main() -> int:
         return 1
 
     present = set(files)
-    missing = sorted(REQUIRED_FILES - present)
-    failures.extend(f"missing required file: {path}" for path in missing)
+    failures.extend(
+        f"missing required file: {path}" for path in sorted(REQUIRED_FILES - present)
+    )
 
     license_files = [path for path in files if path.name.upper().startswith("LICENSE")]
     failures.extend(f"license file is not authorized: {path}" for path in license_files)
 
     image_suffixes = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg"}
-    failures.extend(f"image asset is not authorized: {path}" for path in files if path.suffix.lower() in image_suffixes)
+    failures.extend(
+        f"image asset is not authorized: {path}"
+        for path in files
+        if path.suffix.lower() in image_suffixes
+    )
 
     json_files = [path for path in files if path.suffix == ".json"]
     if not json_files:
@@ -151,8 +193,12 @@ def main() -> int:
             except json.JSONDecodeError as exc:
                 failures.append(f"{relative}: invalid JSON: {exc}")
                 continue
-            if not isinstance(payload, dict) or payload.get("synthetic") is not True:
-                failures.append(f"{relative}: JSON example must declare synthetic true")
+            if not isinstance(payload, dict):
+                failures.append(f"{relative}: JSON root must be an object")
+            elif payload.get("sanitized_public_example") is not True:
+                failures.append(
+                    f"{relative}: JSON example must declare sanitized_public_example true"
+                )
 
     if failures:
         print("publication safety: FAIL")
@@ -160,7 +206,10 @@ def main() -> int:
             print(f"- {failure}")
         return 1
 
-    print(f"publication safety: PASS ({scanned} text files, {len(json_files)} JSON examples)")
+    print(
+        f"publication safety: PASS ({scanned} text files, "
+        f"{len(json_files)} JSON examples)"
+    )
     return 0
 
 

--- a/scripts/summarize_nccl_log.py
+++ b/scripts/summarize_nccl_log.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Summarize fixed-size nccl-tests rows from a local log file."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import statistics
+from pathlib import Path
+
+DATA_ROW = re.compile(
+    r"^\s*(?P<size>\d+)\s+\d+\s+\S+\s+\S+\s+\S+\s+\S+\s+"
+    r"(?P<oop_alg>[-+0-9.eE]+)\s+(?P<oop_bus>[-+0-9.eE]+)\s+(?P<oop_wrong>\d+)\s+"
+    r"(?P<ip_alg>[-+0-9.eE]+)\s+(?P<ip_bus>[-+0-9.eE]+)\s+(?P<ip_wrong>\d+)"
+)
+AVG_ROW = re.compile(r"Avg bus bandwidth\s*:\s*(?P<avg>[-+0-9.eE]+)")
+
+
+def parse_log(text: str) -> dict[str, object]:
+    rows: list[dict[str, object]] = []
+    averages: list[float] = []
+    for line in text.splitlines():
+        match = DATA_ROW.match(line)
+        if match:
+            values = match.groupdict()
+            rows.append(
+                {
+                    "size_bytes": int(values["size"]),
+                    "out_of_place_alg_gb_per_second": float(values["oop_alg"]),
+                    "out_of_place_bus_gb_per_second": float(values["oop_bus"]),
+                    "out_of_place_wrong": int(values["oop_wrong"]),
+                    "in_place_alg_gb_per_second": float(values["ip_alg"]),
+                    "in_place_bus_gb_per_second": float(values["ip_bus"]),
+                    "in_place_wrong": int(values["ip_wrong"]),
+                }
+            )
+        average = AVG_ROW.search(line)
+        if average:
+            averages.append(float(average.group("avg")))
+
+    wrong = sum(
+        int(row["out_of_place_wrong"]) + int(row["in_place_wrong"])
+        for row in rows
+    )
+    summary: dict[str, object] = {
+        "data_rows": len(rows),
+        "reported_average_count": len(averages),
+        "wrong_total": wrong,
+        "rows": rows,
+    }
+    if averages:
+        summary["reported_average_gb_per_second"] = {
+            "values": averages,
+            "mean": statistics.fmean(averages),
+            "median": statistics.median(averages),
+            "minimum": min(averages),
+            "maximum": max(averages),
+        }
+    return summary
+
+
+def self_test() -> None:
+    sample = """
+ 268435456  67108864  float  sum  -1  0  20.00  19.00  0  21.00  20.00  0
+ # Avg bus bandwidth    : 19.5000
+"""
+    result = parse_log(sample)
+    assert result["data_rows"] == 1
+    assert result["wrong_total"] == 0
+    averages = result["reported_average_gb_per_second"]
+    assert isinstance(averages, dict)
+    assert averages["mean"] == 19.5
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("log", nargs="?", type=Path)
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+    if args.self_test:
+        self_test()
+        print("summarize_nccl_log: PASS")
+        return 0
+    if args.log is None:
+        parser.error("a local log path is required unless --self-test is used")
+    print(json.dumps(parse_log(args.log.read_text(encoding="utf-8")), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary\n\nThis draft restores the useful DGX Cluster engineering record instead of replacing it with a generic portfolio summary.\n\nIt preserves the recorded bring-up sequence, software parity work, RoCE troubleshooting, CRS804 forwarding root cause, measured repair results, NCCL tuning profiles and repeat statistics, rack recable revalidation, guarded recovery logic, Raspberry Pi BLE commissioning correction, and open-rack thermal design.\n\n## Publication boundary\n\nLive identities and control topology are not published. The adaptation consistently replaces addresses with RFC 5737 documentation ranges and private names with stable .example aliases. It omits usernames, emails, personal paths, hardware identifiers, account identifiers, secrets, private endpoints, raw captures, exact switch-port numbering, and exact controller/outlet/load mappings.\n\nThe measurements, versions, failure modes, decisions, rollback logic, and operational conclusions remain the recorded engineering work. No benchmark, log, outcome, or test result was fabricated.\n\n## Validation\n\n- publication safety scan: PASS\n- JSON parsing: PASS for all four examples\n- Python compile: PASS\n- NCCL log parser self-test: PASS\n- workflow YAML parse: PASS\n- Markdown relative-link and fence checks: PASS\n- git diff check: PASS\n- source-to-public factual marker comparison: PASS\n- private source workspace integrity hash: unchanged\n\n## Change boundary\n\nDocumentation and public-safe validation tooling only. No runtime deployment, live infrastructure change, private repository mutation, or merge is included.