### PR TITLE
docs: finish publication readiness cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ This repository is the privacy-reviewed public record of how I brought up, repai
 
 The visual record now follows the power-supply support from the original heat
 pocket through dimensional test prints, final production parts, installation,
-and fan placement. The owner reviewed and approved the visible rack labels and
-cabling in these photographs. See
+and fan placement. I reviewed and approved the visible rack labels and cabling
+in these photographs. See
 [THERMAL-MANAGEMENT.md](docs/THERMAL-MANAGEMENT.md) for the complete build and
 measured fan test.
 
@@ -53,7 +53,7 @@ The detailed context, failed hypotheses, and acceptance boundaries are preserved
 | Path | Contents |
 | --- | --- |
 | [docs/CASE-STUDY.md](docs/CASE-STUDY.md) | Chronological engineering narrative |
-| [docs/MEDIA-REVIEW.md](docs/MEDIA-REVIEW.md) | Staged visual evidence and placement review |
+| [docs/MEDIA-REVIEW.md](docs/MEDIA-REVIEW.md) | Published visual evidence and review record |
 | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | Sanitized architecture and validation flow |
 | [docs/COMMISSIONING.md](docs/COMMISSIONING.md) | Identity-first bring-up and parity gates |
 | [docs/FABRIC-TROUBLESHOOTING.md](docs/FABRIC-TROUBLESHOOTING.md) | RoCE diagnosis, forwarding root cause, repair, and rollback discipline |
@@ -95,9 +95,9 @@ UCX_NET_DEVICES=enp1s0f1np1,enP2p1s0f1np1
 The private working repository remains the operational source of truth. This public repository omits credentials, accounts, personal paths, raw captures, raw logs, hardware identifiers, controller identities, exact physical mappings, and current operational status. It preserves non-identifying measurements and engineering decisions because those are the substance of the work.
 
 Reviewed visual evidence is kept under `media/review/`. Each asset is
-metadata-scrubbed and manually inspected before it can be merged. A staged
-overview is not permission to publish an exact control relationship, power map,
-or live topology.
+metadata-scrubbed and manually inspected before publication. Publishing a rack
+overview does not disclose or authorize publication of an exact control
+relationship, power map, or live topology.
 
 See [docs/PUBLICATION-SAFETY.md](docs/PUBLICATION-SAFETY.md) for the enforced boundary.
 

--- a/docs/MEDIA-REVIEW.md
+++ b/docs/MEDIA-REVIEW.md
@@ -1,9 +1,9 @@
 # Media Review: Rack, PSU Supports, and Thermal Evidence
 
-The owner supplied and approved thirteen HEIC photographs for this draft. Each
+I supplied and approved thirteen HEIC photographs for publication. Each
 public copy was converted to JPEG, resized to a maximum long edge of `1800`
 pixels, saved without EXIF or location metadata, and manually inspected. The
-original attachments remain unchanged.
+original attachments remain unchanged in the private working record.
 
 The existing rack overview remains part of the review set:
 
@@ -24,8 +24,8 @@ The existing rack overview remains part of the review set:
 | 9 | `media/review/09-final-clips-installed-side.jpg` | Installed support geometry from the side |
 | 10 | `media/review/10-final-clips-installed-rear.jpg` | Installed support set from the rear |
 | 11 | `media/review/11-fan-below-psu-standoffs.jpg` | Fan position below the raised PSU bricks |
-| 12 | `media/review/12-completed-rack-rear-sanitized.jpg` | Completed rear arrangement with visible owner-approved equipment labels |
-| 13 | `media/review/13-completed-rack-front-sanitized.jpg` | Completed front arrangement with visible owner-approved rack labels and cabling |
+| 12 | `media/review/12-completed-rack-rear-sanitized.jpg` | Completed rear arrangement with reviewed equipment labels |
+| 13 | `media/review/13-completed-rack-front-sanitized.jpg` | Completed front arrangement with reviewed rack labels and cabling |
 
 The complete sequence is placed in
 [THERMAL-MANAGEMENT.md](THERMAL-MANAGEMENT.md). Selected frames appear in the
@@ -33,10 +33,10 @@ README and case study where they support the broader engineering timeline.
 
 ## Pixel review
 
-All thirteen photographs were manually inspected. The owner approved the
-visible Spark names, power-unit names, equipment model markings, rack labels,
-numbered cable marker, switch and patch-panel cabling, and the completed front
-and rear rack views. No pixels are blurred, masked, pixelated, or replaced.
+I manually inspected all thirteen photographs and approved the visible Spark
+names, power-unit names, equipment model markings, rack labels, numbered cable
+marker, switch and patch-panel cabling, and the completed front and rear rack
+views. No pixels are blurred, masked, pixelated, or replaced.
 
 The photographs contain no visible IP addresses, MAC addresses, usernames,
 credentials, account data, or private controller identifiers. The word
@@ -50,4 +50,5 @@ not a pixel redaction.
 - JPEG metadata markers are rejected by the publication checker.
 - Exact addresses, credentials, private controller identifiers, and operational
   configuration remain excluded from the repository text.
-- This remains a draft PR until the owner separately authorizes merge.
+- Future additions require the same metadata, pixel, placement, and privacy
+  review before publication.

--- a/docs/PUBLICATION-SAFETY.md
+++ b/docs/PUBLICATION-SAFETY.md
@@ -41,12 +41,12 @@ The addresses are reserved for documentation and do not identify the live enviro
 
 ## Reviewed visual evidence
 
-Unreviewed screenshots, rack photos, and equipment maps remain excluded. A
-user-owned image may be staged under `media/review/` only when its metadata has
+Unreviewed screenshots, rack photos, and equipment maps remain excluded. An
+image may be published under `media/review/` only when its metadata has
 been removed, its pixels have been manually inspected, and its placement and
 review status are documented in [MEDIA-REVIEW.md](MEDIA-REVIEW.md). The reviewed
-set records the PSU-support design and rack thermal work. The owner approved the
-visible Spark names, power-unit names, model markings, rack labels, and cabling.
+set records the PSU-support design and rack thermal work. I approved the visible
+Spark names, power-unit names, model markings, rack labels, and cabling.
 The photos contain no visible IP addresses, MAC addresses, credentials, account
 data, or private controller identifiers.
 

--- a/docs/SHARE.md
+++ b/docs/SHARE.md
@@ -2,9 +2,9 @@
 
 ## Short post
 
-I rebuilt my DGX Cluster public repo around the work itself: the slow underlay, the switch forwarding root cause, the dual-rail repair, the NCCL tuning, the recable failure, and the validation that followed. The measurements are real. The live identities and topology are not published.
+I rebuilt my DGX Cluster public repo around the work itself: the slow underlay, the switch forwarding root cause, the dual-rail repair, NCCL tuning, rack recabling, custom-printed PSU supports, and a bounded AC Infinity fan test. The measurements and build photographs are real. The live identities and topology are not published.
 
-## Thread draft
+## X thread
 
 ### 1
 
@@ -37,3 +37,15 @@ I also included the power/BLE commissioning failure that mattered: a valid ackno
 ### 8
 
 Everything public uses documentation addresses and stable aliases. The technical decisions and measurements remain; the live topology, control map, accounts, and raw captures do not.
+
+### 9
+
+The rack work was mechanical as well as computational. I designed PSU supports to lift eight warm power bricks off the rack surfaces, tested four clip dimensions instead of reprinting the full part four times, and placed the fan below the resulting open path.
+
+### 10
+
+A bounded fan test recorded `82.4 F` with the fan on, `82.8 F` after two minutes off, and `82.5 F` after restoration and independent readback. That proves the control path and local temperature response, not maximum thermal capacity or measured CFM.
+
+### 11
+
+The public record includes the print iterations, completed rack photographs, and engineering sequence. Image metadata is removed; the visible equipment labels and cabling were reviewed before publication.

--- a/docs/SOURCE-ADAPTATION.md
+++ b/docs/SOURCE-ADAPTATION.md
@@ -50,8 +50,8 @@ The public cluster record does not import:
 
 - raw evidence directories or logs;
 - private inventory and topology manifests;
-- unreviewed screenshots or rack photos; fourteen owner-reviewed JPEGs are
-  staged under `media/review/` with metadata removal and documented visual
+- unreviewed screenshots or rack photos; fourteen reviewed JPEGs are published
+  under `media/review/` with metadata removal and documented visual
   review;
 - controller captures or live power maps;
 - unrelated training corpora and model artifacts;

--- a/docs/THERMAL-MANAGEMENT.md
+++ b/docs/THERMAL-MANAGEMENT.md
@@ -79,10 +79,10 @@ publishing the exact outlet selector or controller identity.
 
 ![Fan below the PSU supports](../media/review/11-fan-below-psu-standoffs.jpg)
 
-The resulting rack is shown from both sides. The owner reviewed and approved
-the visible Spark names, power-unit names, equipment model markings, rack
-labels, and cabling. The public JPEGs retain those pixels while removing the
-original image metadata.
+The resulting rack is shown from both sides. I reviewed and approved the visible
+Spark names, power-unit names, equipment model markings, rack labels, and
+cabling. The public JPEGs retain those pixels while removing the original image
+metadata.
 
 ![Completed rack from the rear](../media/review/12-completed-rack-rear-sanitized.jpg)
 


### PR DESCRIPTION
## What changed

- removes stale draft and staged-media language after the approved merge
- uses first-person project voice throughout the rack and thermal record
- keeps every measurement, image, and engineering conclusion unchanged
- updates the share copy to include the printed PSU supports and bounded AC Infinity fan test

## Validation

- `python3 scripts/check_publication_safety.py`
- `git diff --check`
- review confirmed no measurement or image changes