### PR TITLE
docs: add copyright and reuse terms

### DIFF
--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,0 +1,17 @@
+# Copyright
+
+Copyright (c) 2026 Gumbii Digital. All rights reserved.
+
+Unless a file or third-party notice states otherwise, the original text,
+photographs, diagrams, examples, and software in this repository may not be
+copied, modified, distributed, sublicensed, or used commercially without prior
+written permission from Gumbii Digital.
+
+Public availability on GitHub does not grant an open-source license. GitHub's
+Terms of Service continue to govern use of GitHub features, including viewing
+and forking.
+
+Third-party names, product names, and trademarks remain the property of their
+respective owners. Any third-party material retains its original license and
+notice requirements.
+

--- a/README.md
+++ b/README.md
@@ -107,4 +107,9 @@ See [docs/PUBLICATION-SAFETY.md](docs/PUBLICATION-SAFETY.md) for the enforced bo
 - The public aliases are not valid deployment inventory.
 - The BLE work proves an identity-verified read path and a critical decoder correction; it does not claim unattended relay recovery is enabled.
 - The fan test proves a bounded control-path and temperature response. It is not a CFM study, long-duration thermal-capacity test, or maximum safe workload claim.
-- No license has been selected for this repository.
+- This repository is published without an open-source license.
+
+## Copyright
+
+Copyright (c) 2026 Gumbii Digital. All rights reserved. See
+[COPYRIGHT.md](COPYRIGHT.md) for the publication and reuse terms.


### PR DESCRIPTION
## What changed

- adds a root `COPYRIGHT.md` reserving Gumbii Digital's rights
- links the notice from the README
- clarifies that public availability does not grant an open-source license
- preserves third-party licenses, notices, product names, and trademarks

## Validation

- repository publication-safety checker passes
- `git diff --check` passes
- no `LICENSE` file or open-source grant was added