### PR TITLE
License original work under MIT

### DIFF
--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,17 +1,12 @@
-# Copyright
+# Copyright and license scope
 
-Copyright (c) 2026 Gumbii Digital. All rights reserved.
+Copyright (c) 2026 Gumbii Digital.
 
-Unless a file or third-party notice states otherwise, the original text,
-photographs, diagrams, examples, and software in this repository may not be
-copied, modified, distributed, sublicensed, or used commercially without prior
-written permission from Gumbii Digital.
+Gumbii Digital's original code, documentation, examples, data arrangement,
+diagrams, and media in this repository are licensed under the [MIT License](LICENSE).
+You may use, copy, modify, distribute, sublicense, and sell that material under
+the terms of that license.
 
-Public availability on GitHub does not grant an open-source license. GitHub's
-Terms of Service continue to govern use of GitHub features, including viewing
-and forking.
-
-Third-party names, product names, and trademarks remain the property of their
-respective owners. Any third-party material retains its original license and
-notice requirements.
-
+The MIT License does not transfer ownership of third-party material, product
+names, logos, or trademarks. Those remain subject to their owners' licenses
+and notices. Repository-specific notices identify known exclusions.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Gumbii Digital
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -172,9 +172,12 @@ See [docs/PUBLICATION-SAFETY.md](docs/PUBLICATION-SAFETY.md) for the enforced bo
 - The public aliases are not valid deployment inventory.
 - The BLE work proves an identity-verified read path and a critical decoder correction; it does not claim unattended relay recovery is enabled.
 - The fan test proves a bounded control-path and temperature response. It is not a CFM study, long-duration thermal-capacity test, or maximum safe workload claim.
-- This repository is published without an open-source license.
+- Operational omissions limit what can be reproduced, but the material that is
+  published here is open source under the MIT License.
 
-## Copyright
+## License
 
-Copyright (c) 2026 Gumbii Digital. All rights reserved. See
-[COPYRIGHT.md](COPYRIGHT.md) for the publication and reuse terms.
+Gumbii Digital's original code, documentation, examples, data, diagrams, and
+media are available under the [MIT License](LICENSE). Third-party components,
+assets, product names, and trademarks retain their respective terms; see
+[COPYRIGHT.md](COPYRIGHT.md) for scope.

--- a/scripts/check_publication_safety.py
+++ b/scripts/check_publication_safety.py
@@ -14,6 +14,7 @@ SELF = Path("scripts/check_publication_safety.py")
 FENCE = chr(96) * 3
 REQUIRED_FILES = {
     Path("README.md"),
+    Path("LICENSE"),
     Path("docs/ARCHITECTURE.md"),
     Path("docs/CASE-STUDY.md"),
     Path("docs/MEDIA-REVIEW.md"),
@@ -204,9 +205,6 @@ def main() -> int:
     failures.extend(
         f"missing required file: {path}" for path in sorted(REQUIRED_FILES - present)
     )
-
-    license_files = [path for path in files if path.name.upper().startswith("LICENSE")]
-    failures.extend(f"license file is not authorized: {path}" for path in license_files)
 
     image_suffixes = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg"}
     for relative in files:


### PR DESCRIPTION
## Summary
- license Gumbii Digital's original repository material under MIT
- preserve third-party licenses, notices, and trademark ownership
- update publication-safety policy and integrity manifests where applicable

## Verification
- local publication-safety check passed
- remote branch is one commit ahead of `main` and zero commits behind
- changed-file comparison matches the reviewed licensing scope